### PR TITLE
fix: Fix Ollama Ingress Config

### DIFF
--- a/apps/kyrion/ai/ollama-values.yaml
+++ b/apps/kyrion/ai/ollama-values.yaml
@@ -5,9 +5,11 @@ ollama:
     run:
       - gemma3:12b
 ingress:
+  enabled: true
   className: tailscale
   hosts:
-    - paths:
+    - host: ollama
+      paths:
         - path: /
           pathType: Prefix
   tls:


### PR DESCRIPTION
Fixes the ingress for Ollama by enabling it explicitly and making sure the host rules are set correctly in `apps/kyrion/ai/ollama-values.yaml`.