### PR TITLE
ci(charts): add pr-validate-charts.yml (ct lint + helm unittest)

### DIFF
--- a/.github/workflows/pr-validate-charts.yml
+++ b/.github/workflows/pr-validate-charts.yml
@@ -1,9 +1,16 @@
 name: PR Validate Charts
 
+# This workflow uses a top-level `paths:` filter, so it only runs on PRs that touch the
+# listed paths. The workflow file itself is included below so that changes to its own
+# logic still trigger it. NOTE: this filter is trigger-level only — it does NOT make it
+# safe to mark this workflow as a required status check in branch protection yet. A PR
+# that doesn't touch these paths would leave the check permanently "Pending" and block
+# merge. See #67 for the fan-in "gate" job refactor needed before this can be required.
 on:
   pull_request:
     paths:
       - charts/**
+      - .github/workflows/pr-validate-charts.yml
 
 permissions:
   contents: read

--- a/.github/workflows/pr-validate-charts.yml
+++ b/.github/workflows/pr-validate-charts.yml
@@ -1,0 +1,41 @@
+name: PR Validate Charts
+
+on:
+  pull_request:
+    paths:
+      - charts/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+
+      - name: Run ct lint (only changed charts)
+        run: ct lint --config ct.yaml --target-branch main
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2
+
+      - name: Run helm unittest (cron-job)
+        run: helm unittest charts/cron-job
+
+      - name: Run helm unittest (onechart)
+        run: helm unittest charts/onechart

--- a/.github/workflows/pr-validate-charts.yml
+++ b/.github/workflows/pr-validate-charts.yml
@@ -39,7 +39,7 @@ jobs:
         run: ct lint --config ct.yaml --target-branch main
 
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2 --verify=false
 
       - name: Run helm unittest (cron-job)
         run: helm unittest charts/cron-job

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@ This repo has no application build/test suite — "validation" means rendering m
 - **Lint YAML**: `yamllint .` (config in `.yamllint.yaml`; `.md` files and `clusters/*/flux-system/` are excluded)
 - **Validate `renovate.json`**: `renovate-config-validator` (Renovate CLI is preinstalled in the devcontainer via `ghcr.io/devcontainers-extra/features/renovate-cli:2`; outside the devcontainer, run `npx --yes --package renovate -- renovate-config-validator` instead)
 - **Dry-run Renovate locally** (see what updates it would open, without pushing anything): `LOG_LEVEL=debug RENOVATE_PLATFORM=local renovate` from the repo root
+- **Lint a local Helm chart** (`charts/cron-job`, `charts/onechart`): `ct lint --config ct.yaml --target-branch main` (or `helm lint <chart>` for a single chart without `ct`)
+- **Run a local chart's `helm-unittest` suite**: `helm unittest <chart>` (e.g. `helm unittest charts/onechart`); requires the `helm-unittest` plugin (`helm plugin install https://github.com/helm-unittest/helm-unittest`)
 - **Bootstrap Flux on a new cluster** (rarely needed, destructive on a fresh cluster only): `scripts/bootstrap_flux.sh`
 - **Collect a monitoring baseline** (for troubleshooting/regressions): `scripts/collect-monitoring-baseline.sh`
 - There is no `clean`, `format`, or dev server target — YAML/Helm files are edited directly and validated via the render commands above.
@@ -81,6 +83,7 @@ This repo has no application build/test suite — "validation" means rendering m
 ## PR Validation Workflows
 - Lint YAML manifests on every PR: `.github/workflows/pr-lint-yaml.yml`
 - Scan PR diffs for leaked secrets: `.github/workflows/pr-secret-scan.yml`
+- Validate Helm charts (`ct lint` + `helm unittest`) on `charts/**` changes: `.github/workflows/pr-validate-charts.yml`
 - See `docs/ci/pr-validation.md` for the full two-level validation model.
 
 ## Copilot-Specific Workflows

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,14 @@
+# Configuration for helm/chart-testing (ct), used by .github/workflows/pr-validate-charts.yml.
+# See https://github.com/helm/chart-testing#configuration for all available options.
+
+# charts/ contains the vendored Helm charts (cron-job, onechart); ct auto-detects which of
+# them changed against --target-branch.
+chart-dirs:
+  - charts
+
+# charts/* track the vendored Gimlet "onechart" upstream version, not an independent local
+# semver, so don't force a version bump on every PR.
+check-version-increment: false
+
+# The vendored upstream Chart.yaml files don't declare a maintainers field.
+validate-maintainers: false

--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -45,6 +45,8 @@ ct lint --config ct.yaml --target-branch main
 helm lint charts/onechart
 
 # Run the existing helm-unittest suite for a chart (requires the helm-unittest plugin)
+# --verify=false: the plugin source doesn't support provenance verification, which newer
+# Helm CLIs require by default
 helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2 --verify=false
 helm unittest charts/cron-job
 helm unittest charts/onechart

--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -18,7 +18,12 @@ See `AGENTS.md` for the full command reference used by these workflows.
 ### `pr-validate-charts.yml` — Helm chart lint and unit tests
 
 **Workflow:** `.github/workflows/pr-validate-charts.yml`
-**Trigger:** `pull_request` on changes under `charts/**`.
+**Trigger:** `pull_request` on changes under `charts/**` (the workflow file's own path is
+also included in the filter so changes to its logic are validated too). Note that this
+`paths:` filter is trigger-level only — it does not make this workflow safe to mark as a
+required status check in branch protection, since a PR that doesn't touch these paths
+would leave the check permanently "Pending" and block merge; see #67 for the fan-in
+"gate" job refactor needed before this workflow can be required.
 
 Validates the vendored Helm charts (`charts/cron-job`, `charts/onechart`):
 

--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -14,3 +14,33 @@ See `AGENTS.md` for the full command reference used by these workflows.
 - **Local equivalent:** Install [gitleaks](https://github.com/gitleaks/gitleaks) and run `gitleaks detect --source . -v` (or `gitleaks protect --staged -v` before committing) to scan for secrets before opening a PR.
 
 ## Level 2 — domain-specific checks (path-filtered)
+
+### `pr-validate-charts.yml` — Helm chart lint and unit tests
+
+**Workflow:** `.github/workflows/pr-validate-charts.yml`
+**Trigger:** `pull_request` on changes under `charts/**`.
+
+Validates the vendored Helm charts (`charts/cron-job`, `charts/onechart`):
+
+- **`ct lint`** ([`helm/chart-testing-action`](https://github.com/helm/chart-testing-action)): auto-detects which
+  chart(s) changed relative to `main` and runs `helm lint` plus chart schema/`values.schema.json` validation against
+  each. Configured via the repo-root `ct.yaml` (`check-version-increment: false`, since these charts track the
+  vendored Gimlet `onechart` upstream version rather than an independent local semver; `validate-maintainers: false`,
+  since the vendored `Chart.yaml` files don't declare a `maintainers` field).
+- **`helm unittest`** ([`helm-unittest`](https://github.com/helm-unittest/helm-unittest) plugin): runs the
+  `suite:`/`tests:`/`asserts:` test files under `charts/*/tests/*_test.yaml` against both charts.
+
+**Local equivalent:**
+
+```bash
+# Lint only the chart(s) changed vs. main (matches the ct lint step)
+ct lint --config ct.yaml --target-branch main
+
+# Or lint a single chart directly with Helm (no ct required)
+helm lint charts/onechart
+
+# Run the existing helm-unittest suite for a chart (requires the helm-unittest plugin)
+helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2 --verify=false
+helm unittest charts/cron-job
+helm unittest charts/onechart
+```


### PR DESCRIPTION
Closes #54

## Summary

Adds `.github/workflows/pr-validate-charts.yml`, wiring up the 48 existing `helm-unittest` test files under `charts/*/tests/*_test.yaml` that were never executed in CI:

- **Trigger**: `pull_request` on changes under `charts/**`.
- **`ct lint`** via `helm/chart-testing-action` (installs the `ct` CLI): `ct lint --config ct.yaml --target-branch main` auto-detects which of `charts/cron-job`/`charts/onechart` changed and runs `helm lint` + chart-schema/`values.schema.json` validation against them.
- **`helm unittest`**: installs Helm (`azure/setup-helm`) + the `helm-unittest` plugin, then runs `helm unittest` against both `charts/cron-job` and `charts/onechart`.
- New `ct.yaml` (repo root, per chart-testing's documented default config location) with:
  - `chart-dirs: [charts]`
  - `check-version-increment: false` — these charts track the vendored Gimlet `onechart` upstream version, not an independent local semver.
  - `validate-maintainers: false` — the vendored `Chart.yaml` files don't declare a `maintainers` field (discovered while testing locally; see below).
- Follows the repo's workflow conventions: `pull_request` (not `pull_request_target`), `runs-on: ubuntu-latest`, `permissions: contents: read`, `concurrency` group with cancel-in-progress, `actions/checkout@v7` (bare major pin), and full-commit-SHA pins with trailing `# vX.Y.Z` comments for the two third-party actions (`azure/setup-helm`, `helm/chart-testing-action`).
- Docs: added a "PR Validation Workflows" subsection under `AGENTS.md` → "Primary Workflows" (plus local-equivalent commands under "Essential Commands"), and created `docs/ci/pr-validation.md` with the required skeleton (Level 1/Level 2 headings) and a `### pr-validate-charts.yml` section under Level 2.

## What I verified locally vs. deferred to CI

This sandbox doesn't have `helm`/`ct` preinstalled, so I installed them manually to validate the actual logic (not just YAML shape):

- ✅ Installed Helm v3.19.0 and the `helm-unittest` plugin (`v1.1.2`) locally and ran `helm unittest charts/cron-job` and `helm unittest charts/onechart` — **all 49 test suites / 117 assertions pass** (11 suites/18 tests in `cron-job`, 38 suites/99 tests in `onechart`).
- ✅ Installed the `ct` CLI (v3.14.0, matching `chart-testing-action`'s default) plus `yamllint`/`yamale` (the deps `chart-testing-action` installs) and ran `ct lint --config ct.yaml --all` against both charts — **passes** (this is what surfaced the need for `validate-maintainers: false`, which isn't mentioned in the issue but is required for lint to pass on these vendored charts).
- ✅ Ran `ct lint --config ct.yaml --target-branch main` on this branch — correctly reports "No chart changes detected" since this PR doesn't touch `charts/**` itself (as expected; the workflow's `paths: charts/**` filter means it won't even trigger on this PR, only on future chart PRs).
- ✅ `python3 -c "import yaml; ..."` sanity-checked the new workflow YAML and `ct.yaml` for well-formedness, and ran `yamllint -c .yamllint.yaml ct.yaml` (clean).
- ⚠️ **Deferred to real CI**: I could not run the actual `helm/chart-testing-action` composite action or `azure/setup-helm` GitHub Action locally (no `act`/runner in this sandbox) — I verified their underlying behavior (installed `ct`/Helm versions, `CT_CONFIG_DIR` env var wiring for the bundled `chart_schema.yaml`/`lintconf.yaml`) by reading their `action.yml`/`ct.sh` source and reproducing the equivalent steps manually, but the workflow itself hasn't executed inside GitHub Actions yet.
- ⚠️ I did not test a PR that actually modifies `charts/**` to confirm the change-detection path end-to-end (only-changed-chart linting); that's naturally exercised by the next real chart-touching PR.

## Constraints followed

- Scope limited to this issue's workflow file + the required `AGENTS.md`/`docs/ci/pr-validation.md` updates — no other pending PR-validation workflow files were touched.
- Not merging/approving this PR or closing the issue manually.
