### PR TITLE
fix(devcontainer): preserve LF in feature scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.devcontainer/features/*/install.sh text eol=lf


### PR DESCRIPTION
## What changed

- Add a `.gitattributes` rule that forces LF line endings for local Dev Container feature `install.sh` scripts.

## Why

On Windows, Git checked these scripts out with CRLF line endings. During the Linux image build, their shebang became `/bin/sh\r`, causing the local `flux-operator-mcp` feature to fail with `./install.sh: not found`.

## Impact

The Elysium repository can now be rebuilt and opened successfully in its VS Code Dev Container from Windows. The rule also protects the other local feature installers from the same failure.

## Validation

- `git check-attr text eol -- .devcontainer/features/*/install.sh`
- `git diff --check`
- Rebuilt and opened the Dev Container successfully
- Verified `/workspaces/elysium` runs as user `vscode`
- Verified `flux-operator-mcp version 0.57.0` inside the container