### PR TITLE
feat(ci): add PR safety controls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Global ownership is informational in the initial PR-only rollout. The ruleset does
+# not require review yet, but this establishes the owner mapping for future hardening.
+* @alecsg77

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# ARC runner-scale-set labels used by repository workflows. Keeping these here
+# lets actionlint validate the rest of each workflow strictly.
+self-hosted-runner:
+  labels:
+    - coder-runner-set
+    - copilot-runner-set
+    - fission-runner-set
+    - raiplaysoundrss-runner-set

--- a/.github/critical-removal-intents/README.md
+++ b/.github/critical-removal-intents/README.md
@@ -1,0 +1,35 @@
+# Critical resource R2 intents
+
+A critical R2 operation is deliberately a two-PR operation:
+
+1. Add an intent file for the resource in this directory. It must declare the
+   policy resource ID, `operation: remove` or `operation: change`, and non-empty
+   `backup` and `rollback` evidence. The normal PR Gate must merge this
+   preparation first. For a resource carrying
+   `kustomize.toolkit.fluxcd.io/prune: disabled`, this is also the only PR that
+   may remove that annotation.
+2. In a later PR, remove the intent file and perform exactly the matching R2
+   operation. For `remove`, remove the target resource as well; for `change`,
+   modify the intended protected resource. The trusted-base guard reports every
+   protected field that changed and permits the operation only when the
+   already-merged intent matches its resource and operation.
+
+The guard consumes the intent so it cannot authorize a later unrelated R2
+operation. It never permits deletion of the five bootstrap composition files or
+any change to `clusters/kyrion/kustomization.yaml`'s fixed resource list.
+
+Examples (replace placeholders with real, non-secret references):
+
+```yaml
+resource: tailscale/connector
+operation: remove
+backup: "Not applicable: Connector has no persistent data; recovery commit <sha>."
+rollback: "Restore infrastructure/configs/tailscale/connector.yaml from commit <sha>."
+```
+
+```yaml
+resource: system-upgrade/plan-crd
+operation: change
+backup: "Plan inventory and CRD backup reference <id>."
+rollback: "Restore the prior pinned CRD artifact from commit <sha>."
+```

--- a/.github/critical-resources.yaml
+++ b/.github/critical-resources.yaml
@@ -1,0 +1,397 @@
+# Resources whose removal or ownership changes have cluster-wide, access-plane, or
+# persistent-data consequences. The trusted-base guard reads this policy from the
+# base branch; a pull request cannot weaken the policy it is evaluated against.
+version: 1
+root_composition:
+  path: clusters/kyrion/kustomization.yaml
+  resources:
+    - apps.yaml
+    - config-map.yaml
+    - infrastructure.yaml
+    - monitoring.yaml
+    - sealed-secrets.yaml
+non_removable_files:
+  - clusters/kyrion/kustomization.yaml
+  - clusters/kyrion/apps.yaml
+  - clusters/kyrion/config-map.yaml
+  - clusters/kyrion/infrastructure.yaml
+  - clusters/kyrion/monitoring.yaml
+  - clusters/kyrion/sealed-secrets.yaml
+# These paths define the enforcement boundary. The guard reads them from the
+# trusted base and rejects a PR that changes one together with a critical
+# resource, so the same PR cannot weaken its own protection.
+tier0_paths:
+  - .github/CODEOWNERS
+  - .github/actionlint.yaml
+  - .github/critical-resources.yaml
+  - .github/workflows/**
+  - scripts/ci/critical_change_guard.py
+# The root render contains these Flux Kustomizations. Dependencies must retain
+# this controller -> configuration -> workload ordering and remain acyclic.
+bootstrap_dependencies:
+  infra-controllers: []
+  infra-configs:
+    - infra-controllers
+  apps:
+    - infra-configs
+  monitoring-controllers:
+    - infra-configs
+  monitoring-configs:
+    - monitoring-controllers
+# Exact safety-preserving transitions that are allowed in a single PR. Any other
+# R2 field change requires a previously merged, consumed R2 intent.
+safe_hardening:
+  deletion_policy: Orphan
+  prune_annotation: disabled
+intent_directory: .github/critical-removal-intents
+render_targets:
+  # Render only local leaf Kustomizations in the trusted-base guard. The full
+  # catalog may gain remote bases outside these safety targets; the guard never
+  # fetches PR-controlled remote bases while comparing critical resources.
+  bootstrap: clusters/kyrion
+  system_upgrade: infrastructure/controllers/system-upgrade
+  flux_operator: infrastructure/controllers/flux-operator
+  flux_instance: infrastructure/configs/flux-instance
+  sealed_secrets: infrastructure/controllers/sealed-secrets
+  tsidp: infrastructure/controllers/tsidp
+  tailscale_operator: infrastructure/controllers/tailscale-operator
+  tailscale: infrastructure/configs/tailscale
+  networking: infrastructure/configs/networking
+  arkham: apps/kyrion/arkham
+# Single-document resources outside a local Kustomization target are parsed as
+# inert YAML. This avoids traversing the controller catalog's legacy remote CRD
+# base while still protecting the credentials that recover the access plane.
+raw_file_targets:
+  tailscale_operator_credentials: clusters/kyrion/infrastructure/controllers/tailscale-operator-sealed-secret.yaml
+  tsidp_auth: clusters/kyrion/infrastructure/controllers/tsidp-auth-sealed-secret.yaml
+resources:
+  - id: bootstrap/apps
+    target: bootstrap
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    namespace: flux-system
+    name: apps
+    r2_fields:
+      - spec.dependsOn
+      - spec.sourceRef
+      - spec.prune
+      - spec.deletionPolicy
+      - spec.wait
+      - spec.path
+      - spec.postBuild
+      - metadata.annotations
+  - id: bootstrap/infra-controllers
+    target: bootstrap
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    namespace: flux-system
+    name: infra-controllers
+    r2_fields:
+      - spec.sourceRef
+      - spec.prune
+      - spec.deletionPolicy
+      - spec.wait
+      - spec.path
+      - spec.postBuild
+  - id: bootstrap/infra-configs
+    target: bootstrap
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    namespace: flux-system
+    name: infra-configs
+    r2_fields:
+      - spec.dependsOn
+      - spec.sourceRef
+      - spec.prune
+      - spec.deletionPolicy
+      - spec.wait
+      - spec.path
+      - spec.postBuild
+  - id: bootstrap/monitoring-controllers
+    target: bootstrap
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    namespace: flux-system
+    name: monitoring-controllers
+    r2_fields:
+      - spec.dependsOn
+      - spec.sourceRef
+      - spec.prune
+      - spec.deletionPolicy
+      - spec.wait
+      - spec.path
+      - spec.postBuild
+  - id: bootstrap/monitoring-configs
+    target: bootstrap
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    namespace: flux-system
+    name: monitoring-configs
+    r2_fields:
+      - spec.dependsOn
+      - spec.sourceRef
+      - spec.prune
+      - spec.deletionPolicy
+      - spec.wait
+      - spec.path
+      - spec.postBuild
+  - id: bootstrap/cluster-vars
+    target: bootstrap
+    apiVersion: v1
+    kind: ConfigMap
+    namespace: flux-system
+    name: cluster-vars
+    r2_fields:
+      - metadata.annotations
+  - id: bootstrap/cluster-secret-vars
+    target: bootstrap
+    apiVersion: bitnami.com/v1alpha1
+    kind: SealedSecret
+    namespace: flux-system
+    name: cluster-secret-vars
+    r2_fields:
+      - metadata.annotations
+  - id: tailscale/operator-credentials
+    target: tailscale_operator_credentials
+    apiVersion: bitnami.com/v1alpha1
+    kind: SealedSecret
+    namespace: flux-system
+    name: tailscale-operator-secret
+    r2_fields:
+      - metadata.annotations
+  - id: tsidp/auth-credentials
+    target: tsidp_auth
+    apiVersion: bitnami.com/v1alpha1
+    kind: SealedSecret
+    namespace: tailscale
+    name: tsidp-auth
+    r2_fields:
+      - metadata.annotations
+  - id: system-upgrade/source
+    target: system_upgrade
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: GitRepository
+    namespace: flux-system
+    name: system-upgrade
+    r2_fields:
+      - spec
+  - id: system-upgrade/reconciliation
+    target: system_upgrade
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    namespace: flux-system
+    name: system-upgrade
+    r2_fields:
+      - spec
+  - id: system-upgrade/plan-crd
+    target: system_upgrade
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: plans.upgrade.cattle.io
+    r2_fields:
+      - spec
+  - id: flux/operator
+    target: flux_operator
+    apiVersion: helm.toolkit.fluxcd.io/v2
+    kind: HelmRelease
+    namespace: flux-system
+    name: flux-operator
+    r2_fields:
+      - metadata.annotations
+      - spec.chartRef
+      - spec.install
+      - spec.upgrade
+  - id: flux/web-oidc-credentials
+    target: flux_operator
+    apiVersion: bitnami.com/v1alpha1
+    kind: SealedSecret
+    namespace: flux-system
+    name: flux-web-client
+    r2_fields:
+      - metadata.annotations
+  - id: flux/instance
+    target: flux_instance
+    apiVersion: helm.toolkit.fluxcd.io/v2
+    kind: HelmRelease
+    namespace: flux-system
+    name: flux-instance
+    r2_fields:
+      - metadata.annotations
+      - spec.dependsOn
+      - spec.chartRef
+      - spec.values.instance.sync
+  - id: sealed-secrets/controller
+    target: sealed_secrets
+    apiVersion: helm.toolkit.fluxcd.io/v2
+    kind: HelmRelease
+    namespace: flux-system
+    name: sealed-secrets
+    r2_fields:
+      - metadata.annotations
+      - spec.chart
+      - spec.install
+      - spec.upgrade
+  - id: tsidp/release
+    target: tsidp
+    apiVersion: helm.toolkit.fluxcd.io/v2
+    kind: HelmRelease
+    namespace: tailscale
+    name: tsidp
+    r2_fields:
+      - metadata.annotations
+      - spec.dependsOn
+      - spec.chart
+      - spec.install
+      - spec.upgrade
+      - spec.values.volumes
+  - id: tailscale/operator
+    target: tailscale_operator
+    apiVersion: helm.toolkit.fluxcd.io/v2
+    kind: HelmRelease
+    namespace: flux-system
+    name: tailscale-operator
+    r2_fields:
+      - metadata.annotations
+      - spec.targetNamespace
+      - spec.chart
+      - spec.chartRef
+      - spec.install
+      - spec.upgrade
+  - id: tailscale/connector
+    target: tailscale
+    apiVersion: tailscale.com/v1alpha1
+    kind: Connector
+    namespace: tailscale
+    name: connector
+    r1_fields:
+      - spec
+    r2_fields:
+      - metadata.annotations
+  - id: tailscale/default-proxy-class
+    target: tailscale
+    apiVersion: tailscale.com/v1alpha1
+    kind: ProxyClass
+    namespace: tailscale
+    name: default
+    r1_fields:
+      - spec
+    r2_fields:
+      - metadata.annotations
+  - id: tailscale/dns
+    target: tailscale
+    apiVersion: tailscale.com/v1alpha1
+    kind: DNSConfig
+    namespace: tailscale
+    name: ts-dns
+    r1_fields:
+      - spec
+    r2_fields:
+      - metadata.annotations
+  - id: tailscale/tsidp-egress
+    target: tailscale
+    apiVersion: tailscale.com/v1alpha1
+    kind: ProxyGroup
+    name: tsidp-egress
+    r1_fields:
+      - spec
+    r2_fields:
+      - metadata.annotations
+  - id: tailscale/tsidp-egress-service
+    target: tailscale
+    apiVersion: v1
+    kind: Service
+    namespace: kube-system
+    name: tsidp-egress
+    r1_fields:
+      - metadata.annotations
+      - spec
+    r2_fields:
+      - metadata.annotations
+  - id: tailscale/homeassistant-egress-service
+    target: tailscale
+    apiVersion: v1
+    kind: Service
+    namespace: kube-system
+    name: homeassistant-egress
+    r1_fields:
+      - metadata.annotations.tailscale.com/proxy-group
+      - metadata.annotations.tailscale.com/tailnet-fqdn
+      - spec
+    r2_fields:
+      - metadata.annotations
+  - id: tailscale/arkham-ingress
+    target: networking
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    namespace: kube-system
+    name: arkham
+    r1_fields:
+      - spec
+    r2_fields:
+      - metadata.annotations
+  - id: storage/arkham-pvc-storage
+    target: arkham
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    namespace: arkham
+    name: pvc-storage
+    r2_fields:
+      - spec.accessModes
+      - spec.resources.requests.storage
+      - spec.storageClassName
+      - spec.volumeName
+  - id: storage/arkham-pvc-downloads
+    target: arkham
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    namespace: arkham
+    name: pvc-downloads
+    r2_fields:
+      - spec.accessModes
+      - spec.resources.requests.storage
+      - spec.storageClassName
+      - spec.volumeName
+  - id: storage/arkham-pvc-watch
+    target: arkham
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    namespace: arkham
+    name: pvc-watch
+    r2_fields:
+      - spec.accessModes
+      - spec.resources.requests.storage
+      - spec.storageClassName
+      - spec.volumeName
+  - id: storage/arkham-pvc-library
+    target: arkham
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    namespace: arkham
+    name: pvc-library
+    r2_fields:
+      - spec.accessModes
+      - spec.resources.requests.storage
+      - spec.storageClassName
+      - spec.volumeName
+  - id: storage/arkham-pvc-backups
+    target: arkham
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    namespace: arkham
+    name: pvc-backups
+    r2_fields:
+      - spec.accessModes
+      - spec.resources.requests.storage
+      - spec.storageClassName
+      - spec.volumeName
+  - id: storage/arkham-pvc-plex-logs
+    target: arkham
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    namespace: arkham
+    name: pvc-plex-logs
+    r2_fields:
+      - spec.accessModes
+      - spec.resources.requests.storage
+      - spec.storageClassName
+      - spec.volumeName

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Change and risk
+
+- [ ] I identified the affected domain(s): GitOps, charts, Coder, Actions/scripts, functions, or docs.
+- [ ] I ran the applicable local validation commands and recorded them below.
+- [ ] I enabled native auto-merge with `gh pr merge --auto --squash` (or explained why it is not yet available).
+
+## Critical / destructive changes
+
+- [ ] Not applicable.
+- [ ] This is R1: I described the affected critical resource or ownership/access-plane field below.
+- [ ] This is R2: I followed `docs/runbooks/destructive-gitops-change.md`, including the required two-PR intent/consumption sequence and backup/rollback evidence.
+
+## Validation evidence
+
+<!-- Commands run, relevant output, and rollback reference. Never include secrets, private domains, or host details. -->
+
+## Rollback
+
+<!-- Git revert/known-good commit and, when applicable, tested backup restore reference. -->

--- a/.github/workflows/audit-main-integrity.yml
+++ b/.github/workflows/audit-main-integrity.yml
@@ -1,0 +1,41 @@
+name: Audit Main Integrity
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA on main to audit (defaults to the dispatched ref)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: audit-main-integrity-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  verify-pr-association:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail when a main commit has no associated pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ inputs.commit_sha || github.sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pull_requests="$(gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/${REPOSITORY}/commits/${COMMIT_SHA}/pulls" \
+            --jq '.[].number')"
+          if [ -z "$pull_requests" ]; then
+            echo "::error::main commit ${COMMIT_SHA} has no associated pull request"
+            exit 1
+          fi
+          printf 'main commit %s is associated with pull request(s): %s\n' \
+            "$COMMIT_SHA" "$(tr '\n' ' ' <<<"$pull_requests")"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 
@@ -51,28 +51,28 @@ jobs:
         # Required for Copilot coding agent environment to resolve GitHub API endpoints
         # See: https://github.com/orgs/community/discussions/177903#discussioncomment-14841783
         run: |
-          echo "GITHUB_HOST=github.com" >> $GITHUB_ENV
+          echo "GITHUB_HOST=github.com" >> "$GITHUB_ENV"
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v5
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.0.0
         with:
           version: 'latest'
 
       - name: Configure kubectl for in-cluster access
         run: |
           # The runner is inside the cluster with mounted service account
-          mkdir -p $HOME/.kube
-          
+          mkdir -p "$HOME/.kube"
+
           KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
           KUBE_CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          
+
           kubectl config set-cluster kyrion \
             --server=https://kubernetes.default.svc \
-            --certificate-authority=$KUBE_CA \
+            --certificate-authority="$KUBE_CA" \
             --embed-certs=true
-          
+
           kubectl config set-credentials copilot-agent-readonly \
-            --token=$KUBE_TOKEN
+            --token="$KUBE_TOKEN"
           
           kubectl config set-context copilot-agent \
             --cluster=kyrion \

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -2,31 +2,48 @@ name: Deploy Functions
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - 'functions/**'
+      - functions/**
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-functions-main
+  cancel-in-progress: false
+
+env:
+  FISSION_VERSION: v1.21.0
+  FISSION_SHA256: b12b0d4499fa74406b885c3d5be642ae698d87251e3d19ec09c4588935de5555
 
 jobs:
   deploy:
+    # Configure this repository environment to allow only main and scope its
+    # deployment credentials. This workflow never runs on an untrusted PR.
+    environment: functions-production
     runs-on: fission-runner-set
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
+      - name: Check out protected main revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          persist-credentials: false
       
-      - name: Install Fission CLI
+      - name: Install checksum-verified Fission CLI
         run: |
-            curl -Lo fission https://github.com/fission/fission/releases/download/${FISSION_VERSION}/fission-${FISSION_VERSION}-linux-amd64
-            chmod +x fission
-            sudo mv fission /usr/local/bin/
-        env:
-          FISSION_VERSION: 'v1.21.0'
+          set -euo pipefail
+          archive="fission-${FISSION_VERSION}-linux-amd64"
+          curl -fsSL -o fission \
+            "https://github.com/fission/fission/releases/download/${FISSION_VERSION}/${archive}"
+          echo "${FISSION_SHA256}  fission" | sha256sum --check --strict
+          install -m 0755 fission /usr/local/bin/fission
       
-      - name: Verify connection to cluster
+      - name: Verify cluster connection
         run: fission version
       
-      - name: Deploy functions with Fission
+      - name: Apply reviewed function specification
         working-directory: functions
         run: |
           fission spec apply -n default --delete --wait

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,536 @@
+name: PR Gate
+
+on:
+  # The workflow definition is always loaded from the default branch. Every PR
+  # checkout below uses an explicit SHA and is treated as data, never as an
+  # executable workflow/script source.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  KUSTOMIZE_VERSION: v5.8.1
+  KUSTOMIZE_SHA256: 029a7f0f4e1932c52a0476cf02a0fd855c0bb85694b82c338fc648dcb53a819d
+  KUBECONFORM_VERSION: v0.8.0
+  KUBECONFORM_SHA256: 9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883
+  ACTIONLINT_VERSION: 1.7.9
+  ACTIONLINT_SHA256: 233b280d05e100837f4af1433c7b40a5dcb306e3aa68fb4f17f8a7f45a7df7b4
+
+jobs:
+  detect:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      base_sha: ${{ steps.changes.outputs.base_sha }}
+      head_sha: ${{ steps.changes.outputs.head_sha }}
+      gitops: ${{ steps.changes.outputs.gitops }}
+      helm: ${{ steps.changes.outputs.helm }}
+      coder: ${{ steps.changes.outputs.coder }}
+      actions: ${{ steps.changes.outputs.actions }}
+      functions: ${{ steps.changes.outputs.functions }}
+    steps:
+      - name: Check out trusted base
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Detect applicable validation domains
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-head"
+          fetched_head="$(git rev-parse refs/remotes/origin/pr-head)"
+          test "$fetched_head" = "$HEAD_SHA"
+
+          gitops=false
+          helm=false
+          coder=false
+          actions=false
+          functions=false
+
+          while IFS= read -r path; do
+            case "$path" in
+              clusters/*|infrastructure/*|apps/*|monitoring/*)
+                gitops=true
+                ;;
+              charts/*|ct.yaml)
+                helm=true
+                ;;
+              coder/templates/*)
+                coder=true
+                ;;
+              functions/*)
+                functions=true
+                ;;
+              .github/workflows/*|.github/actions/*|scripts/*)
+                actions=true
+                ;;
+            esac
+
+            case "$path" in
+              .github/workflows/**|.github/actionlint.yaml|.github/critical-resources.yaml|.github/CODEOWNERS|scripts/ci/critical_change_guard.py)
+                gitops=true
+                helm=true
+                coder=true
+                actions=true
+                functions=true
+                ;;
+            esac
+          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          {
+            echo "base_sha=$BASE_SHA"
+            echo "head_sha=$HEAD_SHA"
+            echo "gitops=$gitops"
+            echo "helm=$helm"
+            echo "coder=$coder"
+            echo "actions=$actions"
+            echo "functions=$functions"
+          } >> "$GITHUB_OUTPUT"
+
+  baseline:
+    name: baseline
+    runs-on: ubuntu-latest
+    needs: detect
+    steps:
+      - name: Check out trusted base configuration
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.base_sha }}
+          path: base
+          persist-credentials: false
+
+      - name: Check out proposed content as data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Install YAML parser and linter
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y python3-yaml yamllint
+
+      - name: Lint manifest YAML with trusted configuration
+        run: |
+          set -euo pipefail
+          yamllint -c base/.yamllint.yaml clusters infrastructure apps monitoring functions
+
+      - name: Parse CI policy and function YAML
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          import yaml
+
+          for directory in (Path('.github'), Path('functions')):
+              for path in sorted(directory.rglob('*.yaml')):
+                  with path.open(encoding='utf-8') as stream:
+                      list(yaml.safe_load_all(stream))
+          PY
+
+      - name: Reject plaintext Secret manifests anywhere in GitOps content
+        run: |
+          set -euo pipefail
+          if grep -RInE --include='*.yaml' --include='*.yml' \
+            "^[[:space:]]*kind:[[:space:]]*[\"']?Secret[\"']?[[:space:]]*$" \
+            apps clusters infrastructure monitoring functions; then
+            echo "::error::Bare kind: Secret manifests are forbidden; use SealedSecret or a consumer-native Secret reference."
+            exit 1
+          fi
+
+      - name: Scan the proposed revision for leaked secrets
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITLEAKS_ENABLE_COMMENTS: "false"
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
+
+  critical:
+    name: critical GitOps guard
+    runs-on: ubuntu-latest
+    needs: detect
+    steps:
+      - name: Check out trusted base guard and policy
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.base_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Fetch proposed content as inert Git data
+        env:
+          HEAD_SHA: ${{ needs.detect.outputs.head_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-head"
+          test "$(git rev-parse refs/remotes/origin/pr-head)" = "$HEAD_SHA"
+          git worktree add --detach "$RUNNER_TEMP/pr-head" "$HEAD_SHA"
+
+      - name: Install guard dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y python3-yaml
+
+      - name: Install checksum-verified kustomize for the trusted guard
+        run: |
+          set -euo pipefail
+          curl -fsSL -o kustomize.tar.gz \
+            "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          echo "${KUSTOMIZE_SHA256}  kustomize.tar.gz" | sha256sum --check --strict
+          tar -xzf kustomize.tar.gz
+          sudo install -m 0755 kustomize /usr/local/bin/kustomize
+
+      - name: Compare critical base and proposed resources
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/critical_change_guard.py \
+            --base "$GITHUB_WORKSPACE" \
+            --head "$RUNNER_TEMP/pr-head" \
+            --policy .github/critical-resources.yaml \
+            --report "$RUNNER_TEMP/critical-change-report.json"
+
+      - name: Upload critical-change report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: critical-change-report-${{ github.event.pull_request.number }}
+          path: ${{ runner.temp }}/critical-change-report.json
+          if-no-files-found: warn
+          retention-days: 7
+
+  gitops:
+    name: GitOps validation
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.gitops == 'true'
+    steps:
+      - name: Check out proposed manifests as data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.head_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install kustomize
+        run: |
+          set -euo pipefail
+          curl -fsSL -o kustomize.tar.gz \
+            "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          echo "${KUSTOMIZE_SHA256}  kustomize.tar.gz" | sha256sum --check --strict
+          tar -xzf kustomize.tar.gz
+          sudo install -m 0755 kustomize /usr/local/bin/kustomize
+          kustomize version
+
+      - name: Render Kustomize targets without plugins or networked functions
+        run: |
+          set -euo pipefail
+          targets=(
+            clusters/kyrion
+            apps/kyrion/ai
+            apps/kyrion/airflow
+            apps/kyrion/arkham
+            apps/kyrion/coder
+            apps/kyrion/default
+            apps/kyrion/fission
+            apps/kyrion/n8n
+            apps/kyrion/raiplaysoundrss
+            apps/kyrion/registry
+            apps/kyrion/romm
+            infrastructure/controllers
+            infrastructure/configs
+            clusters/kyrion/infrastructure/controllers
+            clusters/kyrion/infrastructure/configs
+            monitoring/controllers
+            clusters/kyrion/monitoring/controllers
+            monitoring/configs
+          )
+          export KUSTOMIZE_PLUGIN_HOME="$RUNNER_TEMP/disabled-kustomize-plugins"
+          mkdir -p rendered
+          for target in "${targets[@]}"; do
+            slug="${target//\//-}"
+            if [ ! -f "$target/kustomization.yaml" ] && [ ! -f "$target/kustomization.yml" ] && [ ! -f "$target/Kustomization" ]; then
+              temporary="$RUNNER_TEMP/$slug"
+              mkdir -p "$temporary"
+              cp -a "$target/." "$temporary/"
+              (cd "$temporary" && kustomize create --autodetect --recursive)
+              kustomize build "$temporary" > "rendered/$slug.yaml"
+            else
+              kustomize build "$target" > "rendered/$slug.yaml"
+            fi
+          done
+
+      - name: Set up Flux CLI
+        uses: fluxcd/flux2/action@16602fa989daa99762f1c6d1186ae2ad1c735815 # v2.9.3
+
+      - name: Build Flux Kustomizations
+        run: |
+          set -euo pipefail
+          flux build kustomization apps --path ./apps/kyrion --kustomization-file clusters/kyrion/apps.yaml --dry-run > rendered/flux-apps.yaml
+          flux build kustomization infra-controllers --path ./clusters/kyrion/infrastructure/controllers --kustomization-file clusters/kyrion/infrastructure.yaml --dry-run > rendered/flux-infra-controllers.yaml
+          flux build kustomization infra-configs --path ./clusters/kyrion/infrastructure/configs --kustomization-file clusters/kyrion/infrastructure.yaml --dry-run > rendered/flux-infra-configs.yaml
+          flux build kustomization monitoring-controllers --path ./clusters/kyrion/monitoring/controllers --kustomization-file clusters/kyrion/monitoring.yaml --dry-run > rendered/flux-monitoring-controllers.yaml
+          flux build kustomization monitoring-configs --path ./monitoring/configs --kustomization-file clusters/kyrion/monitoring.yaml --dry-run > rendered/flux-monitoring-configs.yaml
+
+      - name: Install kubeconform
+        run: |
+          set -euo pipefail
+          curl -fsSL -o kubeconform.tar.gz \
+            "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz"
+          echo "${KUBECONFORM_SHA256}  kubeconform.tar.gz" | sha256sum --check --strict
+          tar -xzf kubeconform.tar.gz kubeconform
+          sudo install -m 0755 kubeconform /usr/local/bin/kubeconform
+
+      - name: Validate rendered schemas (advisory pending issue #66)
+        continue-on-error: true
+        run: |
+          kubeconform -strict -ignore-missing-schemas -summary \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            rendered/
+
+      - name: Scan rendered Kubernetes configuration (advisory pending issue #66)
+        uses: bridgecrewio/checkov-action@9b70310bcd306d11740313070b940167d6b23085 # v12.3115.0
+        with:
+          directory: rendered
+          framework: kubernetes
+          quiet: true
+          soft_fail: true
+
+  helm:
+    name: Helm chart validation
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.helm == 'true'
+    steps:
+      - name: Check out proposed charts as data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+
+      - name: Run chart lint
+        run: ct lint --config ct.yaml --target-branch main
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2 --verify=false
+
+      - name: Run chart unit tests
+        run: |
+          helm unittest charts/cron-job
+          helm unittest charts/onechart
+
+  coder:
+    name: Coder template validation
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.coder == 'true'
+    steps:
+      - name: Check out trusted base for changed-template detection
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.base_sha }}
+          path: base
+          persist-credentials: false
+
+      - name: Check out proposed templates as data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Fetch and identify changed templates
+        id: templates
+        env:
+          BASE_SHA: ${{ needs.detect.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.detect.outputs.head_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-head"
+          test "$(git rev-parse refs/remotes/origin/pr-head)" = "$HEAD_SHA"
+          templates="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- coder/templates/ \
+            | sed -nE 's#^coder/templates/([^/]+)/.*#\1#p' | sort -u)"
+          # Tier 0 guardrail changes force every domain validator. When no Coder
+          # template changed, validate every current template instead of failing
+          # the selected Coder job merely because its diff is empty.
+          if [ -z "$templates" ]; then
+            templates="$(find coder/templates -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)"
+          fi
+          test -n "$templates"
+          printf '%s\n' "$templates" > "$RUNNER_TEMP/changed-coder-templates"
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_wrapper: false
+
+      - name: Validate changed templates without credentials
+        env:
+          TF_IN_AUTOMATION: "true"
+        run: |
+          set -euo pipefail
+          while IFS= read -r template; do
+            directory="coder/templates/$template"
+            if [ ! -d "$directory" ]; then
+              echo "::error::Changed Coder template was removed: $directory"
+              exit 1
+            fi
+            terraform -chdir="$directory" fmt -check -recursive
+            terraform -chdir="$directory" init -backend=false -input=false
+            terraform -chdir="$directory" validate -no-color
+          done < "$RUNNER_TEMP/changed-coder-templates"
+
+      - name: Scan changed templates (advisory pending issue #65)
+        uses: bridgecrewio/checkov-action@9b70310bcd306d11740313070b940167d6b23085 # v12.3115.0
+        with:
+          directory: coder/templates
+          framework: terraform
+          quiet: true
+          soft_fail: true
+
+  actions:
+    name: Actions and scripts validation
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.actions == 'true'
+    steps:
+      - name: Check out trusted actionlint configuration
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.base_sha }}
+          path: base
+          persist-credentials: false
+
+      - name: Check out proposed workflows and scripts as data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Install checksum-verified actionlint
+        run: |
+          set -euo pipefail
+          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
+          echo "${ACTIONLINT_SHA256}  ${archive}" | sha256sum --check --strict
+          tar -xzf "$archive" actionlint
+          sudo install -m 0755 actionlint /usr/local/bin/actionlint
+
+      - name: Lint GitHub Actions workflows
+        run: |
+          cp base/.github/actionlint.yaml .github/actionlint.yaml
+          actionlint .github/workflows/*.yml .github/workflows/*.yaml
+
+      - name: Check shell syntax and lint without executing scripts
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+          for script in scripts/*.sh; do
+            [ -f "$script" ] || continue
+            case "$(head -n 1 "$script")" in
+              *"/bin/sh"*) sh -n "$script" ;;
+              *) bash -n "$script" ;;
+            esac
+          done
+          shellcheck scripts/*.sh
+
+  functions:
+    name: Functions specification validation
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.functions == 'true'
+    steps:
+      - name: Check out proposed function specs as data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Install YAML linter
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y yamllint
+
+      - name: Lint Fission specifications without cluster access
+        run: yamllint -c .yamllint.yaml functions
+
+  required:
+    name: required
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - detect
+      - baseline
+      - critical
+      - gitops
+      - helm
+      - coder
+      - actions
+      - functions
+    steps:
+      - name: Fail closed unless every applicable validator passed
+        env:
+          DETECT: ${{ needs.detect.result }}
+          BASELINE: ${{ needs.baseline.result }}
+          CRITICAL: ${{ needs.critical.result }}
+          GITOPS: ${{ needs.gitops.result }}
+          HELM: ${{ needs.helm.result }}
+          CODER: ${{ needs.coder.result }}
+          ACTIONS: ${{ needs.actions.result }}
+          FUNCTIONS: ${{ needs.functions.result }}
+          GITOPS_APPLICABLE: ${{ needs.detect.outputs.gitops }}
+          HELM_APPLICABLE: ${{ needs.detect.outputs.helm }}
+          CODER_APPLICABLE: ${{ needs.detect.outputs.coder }}
+          ACTIONS_APPLICABLE: ${{ needs.detect.outputs.actions }}
+          FUNCTIONS_APPLICABLE: ${{ needs.detect.outputs.functions }}
+        run: |
+          set -euo pipefail
+          test "$DETECT" = success
+          test "$BASELINE" = success
+          test "$CRITICAL" = success
+
+          for validator in gitops helm coder actions functions; do
+            upper="$(printf '%s' "$validator" | tr '[:lower:]' '[:upper:]')"
+            eval "applicable=\${${upper}_APPLICABLE}"
+            eval "result=\${${upper}}"
+            if [ "$applicable" = true ]; then
+              test "$result" = success || {
+                echo "::error::${validator} validation was applicable but ended as ${result}"
+                exit 1
+              }
+            else
+              test "$result" = skipped || {
+                echo "::error::${validator} validation was not applicable but ended as ${result}"
+                exit 1
+              }
+            fi
+          done
+
+          echo "All applicable validators passed."

--- a/.github/workflows/pr-lint-yaml.yml
+++ b/.github/workflows/pr-lint-yaml.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Install yamllint
         run: |

--- a/.github/workflows/pr-secret-scan.yml
+++ b/.github/workflows/pr-secret-scan.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-validate-charts.yml
+++ b/.github/workflows/pr-validate-charts.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-validate-coder-templates.yml
+++ b/.github/workflows/pr-validate-coder-templates.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
@@ -121,6 +121,12 @@ jobs:
             echo "::warning::coder/templates/${{ matrix.template }}/README.md frontmatter could not be read (missing file or invalid frontmatter)."
             exit 0
           fi
-          [ -z "${{ steps.frontmatter.outputs.displayname }}" ] && echo "::warning::coder/templates/${{ matrix.template }}/README.md is missing 'displayname' in frontmatter." || true
-          [ -z "${{ steps.frontmatter.outputs.description }}" ] && echo "::warning::coder/templates/${{ matrix.template }}/README.md is missing 'description' in frontmatter." || true
-          [ -z "${{ steps.frontmatter.outputs.icon }}" ] && echo "::warning::coder/templates/${{ matrix.template }}/README.md is missing 'icon' in frontmatter." || true
+          if [ -z "${{ steps.frontmatter.outputs.displayname }}" ]; then
+            echo "::warning::coder/templates/${{ matrix.template }}/README.md is missing 'displayname' in frontmatter."
+          fi
+          if [ -z "${{ steps.frontmatter.outputs.description }}" ]; then
+            echo "::warning::coder/templates/${{ matrix.template }}/README.md is missing 'description' in frontmatter."
+          fi
+          if [ -z "${{ steps.frontmatter.outputs.icon }}" ]; then
+            echo "::warning::coder/templates/${{ matrix.template }}/README.md is missing 'icon' in frontmatter."
+          fi

--- a/.github/workflows/pr-validate-flux.yml
+++ b/.github/workflows/pr-validate-flux.yml
@@ -70,7 +70,7 @@ jobs:
           - monitoring/configs
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Install kustomize
         run: |
@@ -104,7 +104,7 @@ jobs:
           echo "slug=$slug" >> "$GITHUB_OUTPUT"
 
       - name: Upload rendered manifest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: rendered-kustomize-${{ steps.render.outputs.slug }}
           path: ${{ steps.render.outputs.path }}
@@ -139,7 +139,7 @@ jobs:
             path: ./monitoring/configs
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
 
       - name: Setup Flux CLI
         uses: fluxcd/flux2/action@16602fa989daa99762f1c6d1186ae2ad1c735815 # v2.9.3
@@ -157,7 +157,7 @@ jobs:
           echo "path=$out" >> "$GITHUB_OUTPUT"
 
       - name: Upload rendered manifest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: rendered-flux-${{ matrix.name }}
           path: ${{ steps.render.outputs.path }}
@@ -171,7 +171,7 @@ jobs:
       - flux-build
     steps:
       - name: Download rendered manifests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:
           pattern: rendered-*
           path: rendered
@@ -219,7 +219,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-coder-templates.yaml
+++ b/.github/workflows/publish-coder-templates.yaml
@@ -2,9 +2,9 @@ name: Publish Coder Template
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - 'coder/templates/**'
+      - coder/templates/**
 
   workflow_dispatch:
     inputs:
@@ -19,15 +19,23 @@ on:
         default: "HEAD"
         type: string
 
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-coder-templates-main
+  cancel-in-progress: false
+
 jobs:
   init:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get changed Coder templates
         id: changes
@@ -38,28 +46,33 @@ jobs:
               # Publish all templates
               find coder/templates -mindepth 1 -maxdepth 1 -type d -exec basename {} \;
             else
-              # Only changed templates
-              git diff --name-only ${{ inputs.since || github.event.commits[0].id }}~1 ${{ github.sha }} -- coder/templates | xargs ls -d 2>/dev/null | sed -r 's/^coder\/templates\/([^\/]+).*$/\1/' | sort | uniq
+              # Only changed templates.
+              base_ref="${{ inputs.since || github.event.commits[0].id }}~1"
+              head_ref="${{ github.sha }}"
+              git diff --name-only "$base_ref" "$head_ref" -- coder/templates \
+                | xargs -r -n1 dirname \
+                | sed -nE 's#^coder/templates/([^/]+).*#\1#p' \
+                | sort -u
             fi
             echo "EOF"
-          } >> $GITHUB_ENV
+          } >> "$GITHUB_ENV"
 
       - name: Get latest commit title to use as template version description
         id: message
-        run:
-          echo "pr_message=$(git log --format=%s -n 1 ${{ github.sha }})" >> $GITHUB_OUTPUT
+        run: |
+          echo "pr_message=$(git log --format=%s -n 1 "${{ github.sha }}")" >> "$GITHUB_OUTPUT"
 
       - name: Define matrix based on changed templates
         id: matrix
         run: |
           if [ -n "$TEMPLATES" ]; then
-            echo "templates=$(echo "$TEMPLATES" | jq -c -R -s 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
+            echo "templates=$(printf '%s' "$TEMPLATES" | jq -c -R -s 'split("\n") | map(select(length > 0))')" >> "$GITHUB_OUTPUT"
           else
-            echo "templates=[]" >> $GITHUB_OUTPUT
+            echo "templates=[]" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload Coder templates
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: templates
           path: coder/templates
@@ -69,6 +82,9 @@ jobs:
       templates: ${{ steps.matrix.outputs.templates }}
 
   publish:
+    # Configure this repository environment to allow only main and scope the
+    # Coder session token. The publish job never runs for a pull request.
+    environment: coder-production
     runs-on: coder-runner-set
     needs: init
     if: needs.init.outputs.templates != '[]'
@@ -79,20 +95,20 @@ jobs:
 
     steps:
       - name: Download Coder templates
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:
           name: templates
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
       
       - name: Set up terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
       - name: Set up Coder CLI
-        uses: coder/setup-action@v1
+        uses: coder/setup-action@4a607a8113d4e676e2d7c34caa20a814bc88bfda # v1.0.0
         with:
           access_url: "http://coder.coder.svc"
           coder_session_token: ${{ secrets.CODER_SESSION_TOKEN }}
@@ -109,7 +125,7 @@ jobs:
 
       - name: Extract README frontmatter
         id: frontmatter
-        uses: mheap/markdown-meta-action@v1
+        uses: mheap/markdown-meta-action@f2cf287beda7ee926c7c504e9e2adc803d2bb958 # v1.0.1
         with:
           file: ./${{ matrix.template }}/README.md
 

--- a/.github/workflows/update-knowledge-base.yml
+++ b/.github/workflows/update-knowledge-base.yml
@@ -1,289 +1,81 @@
-name: Update Knowledge Base
+name: Extract Knowledge Base Candidate
 
 on:
-  issues:
-    types: [closed, labeled]
   workflow_dispatch:
     inputs:
       issue_number:
-        description: 'Issue number to extract learnings from'
+        description: Issue number to extract learnings from
         required: true
         type: number
 
 permissions:
-  contents: write
+  contents: read
   issues: read
-  pull-requests: write
+
+concurrency:
+  group: extract-knowledge-base-${{ inputs.issue_number }}
+  cancel-in-progress: false
 
 jobs:
-  update-knowledge-base:
-    runs-on: copilot-runner-set
-    # Only run when issue is closed with status:resolved label
-    if: |
-      (github.event_name == 'issues' && github.event.action == 'closed' && contains(github.event.issue.labels.*.name, 'status:resolved')) ||
-      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'status:resolved' && github.event.issue.state == 'closed') ||
-      github.event_name == 'workflow_dispatch'
-    
+  extract:
+    # This is read-only GitHub data processing; it does not need a cluster runner.
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
+      - name: Check out repository context
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Get issue details
-        id: issue
+      - name: Fetch issue as read-only input
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
         run: |
-          ISSUE_NUMBER="${{ github.event.issue.number || inputs.issue_number }}"
-          echo "issue_number=${ISSUE_NUMBER}" >> $GITHUB_OUTPUT
-          
-          # Fetch issue details
-          gh issue view ${ISSUE_NUMBER} --json title,body,labels,comments,closedAt \
-            --jq '{
-              title: .title,
-              body: .body,
-              labels: [.labels[].name],
-              comments: [.comments[] | {author: .author.login, body: .body, createdAt: .createdAt}],
-              closedAt: .closedAt
-            }' > /tmp/issue_data.json
-          
-          echo "Issue data collected"
-          cat /tmp/issue_data.json
+          set -euo pipefail
+          gh issue view "$ISSUE_NUMBER" \
+            --json number,title,body,labels,comments,closedAt \
+            > "$RUNNER_TEMP/issue_data.json"
 
-      - name: Extract knowledge base entry
-        id: extract
+      - name: Generate candidate knowledge-base entry
         run: |
-          # Parse issue data with Python for complex extraction
-          python3 << 'EOF' > /tmp/kb_entry.md
+          set -euo pipefail
+          python3 - "$RUNNER_TEMP/issue_data.json" "$RUNNER_TEMP/kb_entry.md" <<'PY'
           import json
-          import re
+          import sys
           from datetime import datetime
-          
-          with open('/tmp/issue_data.json', 'r') as f:
-              issue = json.load(f)
-          
-          # Extract component from labels
-          components = [l for l in issue['labels'] if l.startswith('component:')]
-          component = components[0].replace('component:', '').title() if components else 'Other'
-          
-          # Extract root cause from labels
-          root_causes = [l for l in issue['labels'] if l.startswith('root-cause:')]
-          root_cause_label = root_causes[0].replace('root-cause:', '').replace('-', ' ').title() if root_causes else 'Unknown'
-          
-          # Extract error patterns from body and comments
-          def extract_code_blocks(text):
-              return re.findall(r'```(?:\w+)?\n(.*?)\n```', text, re.DOTALL)
-          
-          error_blocks = []
-          if issue['body']:
-              error_blocks.extend(extract_code_blocks(issue['body']))
-          
-          # Look for resolution in comments
-          resolution = ""
-          root_cause_analysis = ""
-          pr_link = ""
-          
-          for comment in issue['comments']:
-              body = comment['body']
-              
-              # Look for root cause analysis
-              if '## 🎯 Root Cause Analysis' in body or '## Root Cause' in body:
-                  root_cause_analysis = body
-              
-              # Look for resolution confirmation
-              if '## ✅ Resolution' in body or 'Resolution Validated' in body:
-                  resolution = body
-              
-              # Extract PR links
-              pr_matches = re.findall(r'#(\d+)', body)
-              if pr_matches and 'PR' in body.upper():
-                  pr_link = f"#{pr_matches[0]}"
-          
-          # Extract key error message (first code block or error mention)
-          key_error = ""
-          for block in error_blocks[:3]:  # First 3 code blocks
-              if any(word in block.lower() for word in ['error', 'failed', 'timeout', 'crash']):
-                  key_error = block.strip()[:500]  # Limit to 500 chars
-                  break
-          
-          # Generate knowledge base entry
-          title = issue['title'].replace('[Bug]: ', '').replace('[Troubleshoot]: ', '')
-          closed_date = datetime.fromisoformat(issue['closedAt'].replace('Z', '+00:00')).strftime('%Y-%m-%d')
-          
-          # Extract resolution summary from resolution comment
-          resolution_summary = "See issue for full resolution details"
-          if resolution:
-              lines = resolution.split('\n')
-              for i, line in enumerate(lines):
-                  if 'resolution:' in line.lower() and i + 1 < len(lines):
-                      resolution_summary = lines[i + 1].strip('- ').strip()
-                      break
-          
-          # Build entry
-          entry = f"""
-          ### Issue: {title}
-          
-          **Symptoms**: 
-          {key_error if key_error else 'See issue for symptoms'}
-          
-          **Root Cause**: {root_cause_label}
-          {root_cause_analysis[:300] if root_cause_analysis else ''}
-          
-          **Resolution**: {resolution_summary}
-          
-          **Related Issues**: #{issue_number}
-          {f"**PR**: {pr_link}" if pr_link else ""}
-          
-          **Last Seen**: {closed_date}
-          
-          **Labels**: {', '.join([l for l in issue['labels'] if not l.startswith('status:')])}
-          
+          from pathlib import Path
+
+          issue = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          labels = [label["name"] for label in issue.get("labels", [])]
+          component_labels = [label for label in labels if label.startswith("component:")]
+          component = component_labels[0].removeprefix("component:").replace("-", " ").title() if component_labels else "Other"
+          closed_at = issue.get("closedAt")
+          last_seen = datetime.fromisoformat(closed_at.replace("Z", "+00:00")).date().isoformat() if closed_at else "Not closed"
+          body = (issue.get("body") or "").strip()
+          summary = body[:500] if body else "Review the linked issue for symptoms and resolution."
+          entry = f"""### Issue: {issue['title']}
+
+          **Component**: {component}
+
+          **Candidate summary**:
+          {summary}
+
+          **Related issue**: #{issue['number']}
+
+          **Last seen**: {last_seen}
+
+          **Labels**: {', '.join(labels)}
+
           ---
           """
-          
-          print(entry)
-          
-          # Output component for workflow
-          with open('/tmp/component.txt', 'w') as f:
-              f.write(component)
-          EOF
-          
-          COMPONENT=$(cat /tmp/component.txt)
-          echo "component=${COMPONENT}" >> $GITHUB_OUTPUT
-          echo "entry_file=/tmp/kb_entry.md" >> $GITHUB_OUTPUT
+          Path(sys.argv[2]).write_text(entry, encoding="utf-8")
+          PY
 
-      - name: Update known-issues.md
-        id: update
-        run: |
-          COMPONENT="${{ steps.extract.outputs.component }}"
-          ENTRY_FILE="${{ steps.extract.outputs.entry_file }}"
-          KB_FILE="docs/troubleshooting/known-issues.md"
-          
-          # Create file if doesn't exist
-          if [ ! -f "${KB_FILE}" ]; then
-            cat > "${KB_FILE}" << 'KBEOF'
-          # Known Issues and Resolutions
-          
-          This knowledge base is automatically updated from resolved GitHub Issues. It provides quick reference for common cluster problems and their solutions.
-          
-          **Last Updated**: $(date +%Y-%m-%d)
-          
-          ## How to Use
-          
-          1. Search for your issue by component or error message
-          2. Check the symptoms and root cause
-          3. Try the documented resolution
-          4. If resolution doesn't work, create a new troubleshooting request
-          
-          ---
-          KBEOF
-          fi
-          
-          # Check if component section exists
-          if ! grep -q "## Component: ${COMPONENT}" "${KB_FILE}"; then
-            echo "" >> "${KB_FILE}"
-            echo "## Component: ${COMPONENT}" >> "${KB_FILE}"
-            echo "" >> "${KB_FILE}"
-          fi
-          
-          # Insert entry under component section
-          # Find line number of component section
-          SECTION_LINE=$(grep -n "## Component: ${COMPONENT}" "${KB_FILE}" | cut -d: -f1)
-          NEXT_SECTION_LINE=$(tail -n +$((SECTION_LINE + 1)) "${KB_FILE}" | grep -n "## Component:" | head -1 | cut -d: -f1)
-          
-          if [ -n "${NEXT_SECTION_LINE}" ]; then
-            # Insert before next section
-            INSERT_LINE=$((SECTION_LINE + NEXT_SECTION_LINE))
-          else
-            # Append at end
-            INSERT_LINE=$(wc -l < "${KB_FILE}")
-            INSERT_LINE=$((INSERT_LINE + 1))
-          fi
-          
-          # Create temp file with new entry inserted
-          head -n $((SECTION_LINE)) "${KB_FILE}" > /tmp/kb_temp.md
-          cat "${ENTRY_FILE}" >> /tmp/kb_temp.md
-          tail -n +$((SECTION_LINE + 1)) "${KB_FILE}" >> /tmp/kb_temp.md
-          
-          # Replace original file
-          mv /tmp/kb_temp.md "${KB_FILE}"
-          
-          # Update last updated date
-          sed -i "s/\*\*Last Updated\*\*: .*/\*\*Last Updated\*\*: $(date +%Y-%m-%d)/" "${KB_FILE}"
-          
-          echo "updated=true" >> $GITHUB_OUTPUT
-
-      - name: Create Pull Request
-        if: steps.update.outputs.updated == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ISSUE_NUMBER="${{ steps.issue.outputs.issue_number }}"
-          COMPONENT="${{ steps.extract.outputs.component }}"
-          BRANCH_NAME="kb-update-issue-${ISSUE_NUMBER}"
-          
-          # Create branch
-          git checkout -b "${BRANCH_NAME}"
-          
-          # Stage changes
-          git add docs/troubleshooting/known-issues.md
-          
-          # Commit with conventional commit format
-          git commit -m "docs: update knowledge base from issue #${ISSUE_NUMBER}
-
-          Add resolved issue to ${COMPONENT} section of knowledge base.
-          
-          Closes #${ISSUE_NUMBER}"
-          
-          # Push branch
-          git push origin "${BRANCH_NAME}"
-          
-          # Create PR
-          gh pr create \
-            --title "docs: Update knowledge base from issue #${ISSUE_NUMBER}" \
-            --body "## Knowledge Base Update
-
-          Automatically extracted learnings from resolved issue #${ISSUE_NUMBER}.
-
-          ### Component: ${COMPONENT}
-
-          ### Changes
-          - Added issue resolution to `/docs/troubleshooting/known-issues.md`
-          - Updated last modified date
-
-          ### Review
-          Please verify the extracted information is accurate and complete.
-
-          ---
-
-          🤖 This PR was automatically created by the knowledge base update workflow." \
-            --label "documentation" \
-            --label "automated" \
-            --base main \
-            --head "${BRANCH_NAME}"
-          
-          # Auto-merge if all checks pass
-          PR_NUMBER=$(gh pr view "${BRANCH_NAME}" --json number -q .number)
-          gh pr merge "${PR_NUMBER}" --auto --squash
-
-      - name: Post comment on issue
-        if: steps.update.outputs.updated == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ISSUE_NUMBER="${{ steps.issue.outputs.issue_number }}"
-          
-          gh issue comment ${ISSUE_NUMBER} --body "## 📚 Knowledge Base Updated
-
-          This issue's resolution has been added to the knowledge base.
-
-          **Location**: `/docs/troubleshooting/known-issues.md` (Component: ${{ steps.extract.outputs.component }})
-
-          Future similar issues will benefit from this documentation. Thank you for contributing to the knowledge base! 🎉"
+      - name: Upload candidate for a normal documentation PR
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: knowledge-base-candidate-${{ inputs.issue_number }}
+          path: |
+            ${{ runner.temp }}/issue_data.json
+            ${{ runner.temp }}/kb_entry.md
+          retention-days: 7

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -24,3 +24,11 @@ ignore: |
   node_modules/
   *.md
   clusters/*/flux-system/
+  # Go-templated chart sources and helm-unittest suites are validated by ct and
+  # helm-unittest; plain YAML parsing cannot interpret their template/test DSL.
+  charts/**/templates/
+  charts/**/charts/
+  charts/**/tests/
+  # Preserve the upstream formatting and byte-level provenance of this vendored CRD.
+  # Its pinned source SHA-256 is recorded beside the manifest.
+  infrastructure/controllers/system-upgrade/crd.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,12 @@ Vendor-neutral operating guide for AI coding agents working in this repository.
 - Respect Flux dependency ordering: controllers/CRDs before dependent resources.
 - Keep documentation authoritative in `/docs`, not duplicated across agent files.
 
+## Pull Request and Auto-Merge Safety
+- Never commit or push directly to `main`, including when authenticated as a repository administrator. Create a branch, open/update a PR, and enable native squash auto-merge with `gh pr merge --auto --squash`.
+- Never use `gh pr merge --admin`, a direct merge API bypass, or a force push as a routine workaround. The only break-glass path is documented in `docs/runbooks/github-break-glass.md`.
+- After the server-side ruleset migration, `PR Gate / required` is the single required monorepo status. It runs only the validation domains applicable to the PR and fails closed on a failed or unexpected skipped validator; until then, agents still follow this PR-only policy and never exploit legacy settings.
+- Treat changes to Flux bootstrap/ownership, Tailscale access resources, secrets, storage, and CI guardrail files as critical. Follow `docs/runbooks/destructive-gitops-change.md` for R2 removals; persistent-data changes additionally require the backup/restore contract in `docs/runbooks/backup-and-restore.md`.
+
 ## Essential Commands
 This repo has no application build/test suite — "validation" means rendering manifests locally and linting YAML.
 - **Render/build a single app**: `kustomize build apps/base/<app>/`
@@ -83,13 +89,11 @@ This repo has no application build/test suite — "validation" means rendering m
 - Troubleshoot Flux and Kubernetes issues: `.agents/skills/troubleshoot-flux/SKILL.md`
 - Create/update Coder workspace templates: `.agents/skills/coder-templates/SKILL.md`
 
-## PR Validation Workflows
-- Lint YAML manifests on every PR: `.github/workflows/pr-lint-yaml.yml`
-- Scan PR diffs for leaked secrets: `.github/workflows/pr-secret-scan.yml`
-- Validate Helm charts (`ct lint` + `helm unittest`) on `charts/**` changes: `.github/workflows/pr-validate-charts.yml`
-- Validate changed Coder/Terraform templates on PRs: `.github/workflows/pr-validate-coder-templates.yml`
-- Validate Flux/Kustomize manifests on PRs touching `clusters/**`, `infrastructure/**`, `apps/**`, or `monitoring/**`: `.github/workflows/pr-validate-flux.yml`
-- See `docs/ci/pr-validation.md` for the full two-level validation model.
+## PR Validation Workflow
+- `.github/workflows/pr-gate.yml` is the always-present monorepo fan-in. Its final job publishes the only required context: `PR Gate / required`.
+- The gate always runs baseline secret/YAML and trusted-base critical-resource checks; it runs GitOps, chart, Coder, Actions/scripts, and Fission-spec validators only when the detector marks them applicable.
+- Do not make path-filtered workflow jobs required. A skipped domain is accepted only when the gate's detector marked that domain not applicable.
+- See `docs/ci/pr-validation.md` for the validator matrix and `docs/ci/merge-and-automerge-policy.md` for the merge flow.
 
 ## Copilot-Specific Workflows
 - Copilot is the primary hosted workflow for issue-page diagnostics, coding-agent handoff, and GitHub web-based resolution.

--- a/apps/base/fission/kustomization.yaml
+++ b/apps/base/fission/kustomization.yaml
@@ -2,7 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/fission/fission/crds/v1?ref=v1.21.0
+  # Fission v1.21.0 tag, resolved to immutable commit 2853498a9854f00d5aae28e6d54521114bcc43b3.
+  - https://github.com/fission/fission/crds/v1?ref=2853498a9854f00d5aae28e6d54521114bcc43b3
   - repository.yaml
   - release.yaml
   - ingress.yaml

--- a/clusters/kyrion/apps.yaml
+++ b/clusters/kyrion/apps.yaml
@@ -4,6 +4,10 @@ kind: Kustomization
 metadata:
   name: apps
   namespace: flux-system
+  annotations:
+    # Keep the child reconciler if the root Flux sync composition is damaged.
+    # Intentional removal must first remove this annotation in a separate R2 PR.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   dependsOn:
     - name: infra-configs
@@ -13,6 +17,9 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  # Orphan managed resources if this Kustomization object is deleted; normal
+  # source reconciliation still uses prune: true.
+  deletionPolicy: Orphan
   prune: true
   wait: false
   path: ./apps/kyrion

--- a/clusters/kyrion/config-map.yaml
+++ b/clusters/kyrion/config-map.yaml
@@ -3,5 +3,8 @@ kind: ConfigMap
 metadata:
   name: cluster-vars
   namespace: flux-system
+  annotations:
+    # Keep substitution inputs if the root sync composition is accidentally removed.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 data:
   TZ: Europe/Rome

--- a/clusters/kyrion/infrastructure.yaml
+++ b/clusters/kyrion/infrastructure.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: infra-controllers
   namespace: flux-system
+  annotations:
+    # Protect the controller dependency boundary from accidental root-sync pruning.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   interval: 1h
   retryInterval: 5m
@@ -11,6 +14,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  # Preserve managed resources if this child Kustomization is deleted.
+  deletionPolicy: Orphan
   prune: true
   wait: true
   path: ./clusters/kyrion/infrastructure/controllers
@@ -24,6 +29,9 @@ kind: Kustomization
 metadata:
   name: infra-configs
   namespace: flux-system
+  annotations:
+    # Protect configuration and access-plane reconciliation from root-sync pruning.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   dependsOn:
     - name: infra-controllers
@@ -33,6 +41,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  # Preserve managed resources if this child Kustomization is deleted.
+  deletionPolicy: Orphan
   prune: true
   wait: true
   path: ./clusters/kyrion/infrastructure/configs

--- a/clusters/kyrion/infrastructure/controllers/kustomization.yaml
+++ b/clusters/kyrion/infrastructure/controllers/kustomization.yaml
@@ -9,6 +9,28 @@ resources:
 
 patches:
   - target:
+      group: bitnami.com
+      version: v1alpha1
+      kind: SealedSecret
+      name: tailscale-operator-secret
+      namespace: flux-system
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          kustomize.toolkit.fluxcd.io/prune: disabled
+  - target:
+      group: bitnami.com
+      version: v1alpha1
+      kind: SealedSecret
+      name: tsidp-auth
+      namespace: tailscale
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          kustomize.toolkit.fluxcd.io/prune: disabled
+  - target:
       group: helm.toolkit.fluxcd.io
       version: v2
       kind: HelmRelease

--- a/clusters/kyrion/monitoring.yaml
+++ b/clusters/kyrion/monitoring.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 metadata:
   name: monitoring-controllers
   namespace: flux-system
+  annotations:
+    # Protect monitoring controller reconciliation from accidental root-sync pruning.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   dependsOn:
     - name: infra-configs
@@ -15,6 +18,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  # Preserve managed resources if this child Kustomization is deleted.
+  deletionPolicy: Orphan
   path: ./clusters/kyrion/monitoring/controllers
   postBuild:
     substituteFrom:
@@ -26,6 +31,9 @@ kind: Kustomization
 metadata:
   name: monitoring-configs
   namespace: flux-system
+  annotations:
+    # Protect monitoring configuration reconciliation from root-sync pruning.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   dependsOn:
     - name: monitoring-controllers
@@ -37,6 +45,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  # Preserve managed resources if this child Kustomization is deleted.
+  deletionPolicy: Orphan
   path: ./monitoring/configs
   postBuild:
     substituteFrom:

--- a/clusters/kyrion/sealed-secrets.yaml
+++ b/clusters/kyrion/sealed-secrets.yaml
@@ -5,6 +5,9 @@ metadata:
   creationTimestamp: null
   name: cluster-secret-vars
   namespace: flux-system
+  annotations:
+    # Keep required post-build Secret material if root sync composition is damaged.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   encryptedData:
     DOMAIN: AgAiQxNLG/gtlzXXLA0GxKE15nntnWlOgmA4DMmPJOERzA0OkuzbaTl5dZCqtJvdhempMEOuE4aCAJfyBML6iCyQ1bz0JcbnUaiKKP7/9k1j0r87fezj0C3RWnJR7jEpXg6kDKa+2xdnJnH/Q5HesKDLog2gkl/Fexx8ig30NWZ/WnZyV52AR1+fZ+FzrQY3ZA6MqonA6L9T3jTK2ndME+xWeHurBn77NTV/sFf771t/B5Sbb1ObKTl89wpe/NQDGd3D8cVKhJh5zhUBhbjk+BGWU3yGt62utsEmypwbtr5V5AYb21QZKPBIjY8SS7ez3JWLpVm8xKpgqBv/kdGjh9Amm04w5PV4ZYS4+8yDOSnDwWQW/f1mPbylpqzJZ+OAU8V4PPD/MhR+RVBonKGV7PV/wreUXQKZBrx5tXzCXi09M11OQRqWw9s03v6QkgXBu8vgjftan8GF5x+Sm1Y00mA3JCAPIBm5nM4zvWrlSVbgC0/Xi21JcDJrrfsi22pVB3aGpdJroFmFby7qBK4M435gbNXdq1gsrh6Q9eaCfKJT3IDE+Tf37PWPHs8zdg+1Ji8mausFdUOHAfvRBgiXxAJ4RxvyhCceB3CMGslCT9lVskZjEfCe9zHyuGWNrRoEdNful8p/i6+V5HQICfcgBRUi5aVvtwRLN183xiStmAxPP0M8XpvYIKEnF3wDWA8ykvnwz5bA3rc1BJJbErE=

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,10 @@ For AI coding agents, `AGENTS.md` at the repository root is the portable entry p
   - **[Flux Web UI with tsidp OIDC](runbooks/flux-web-ui.md)** - Private-domain authenticated Flux dashboard and read-only RBAC
   - **[Flux Operator Migration](runbooks/flux-operator-migration.md)** - Staged migration from the generated Flux bootstrap
   - **[Gitless ResourceSet Image Automation](runbooks/resourceset-image-automation.md)** - Gitless workload image updates and rollback controls
+  - **[Destructive GitOps Changes](runbooks/destructive-gitops-change.md)** - Two-PR deletion protection, backup evidence, and rollback
+  - **[Backup, Restore, and Out-of-Band Recovery](runbooks/backup-and-restore.md)** - Recovery contract and restore-drill requirements
+  - **[GitHub Merge-Control Break-Glass](runbooks/github-break-glass.md)** - Required-gate recovery without direct pushes
+
 - **[Troubleshooting](troubleshooting/README.md)** - Diagnostic workflows, known issues, and solutions
 
 ## Conventions

--- a/docs/architecture/cluster-architecture.md
+++ b/docs/architecture/cluster-architecture.md
@@ -378,17 +378,28 @@ functions/            # Serverless functions
 ## Disaster Recovery
 
 ### Backup Strategy
-- **Git repository**: Primary backup (entire cluster state)
-- **Sealed secrets key**: Quarterly backup to secure location
-- **Persistent volumes**: Application-specific backup procedures
-- **Monitoring data**: Long-term storage in Minio (Loki/Tempo blocks)
+- **Git repository**: Source of declarative cluster state, not a backup of runtime data.
+- **Sealed Secrets key**: Must be encrypted, stored off-cluster, and recovery-tested.
+- **Persistent volumes and databases**: Require a workload-specific, off-cluster backup
+  and tested restore; a PVC named `pvc-backups` is not sufficient evidence.
+- **Monitoring data**: Retention and any long-term storage must be covered by the same
+  recovery contract.
+
+The required inventory, RPO/RTO, encryption, retention, and restore-drill record
+are defined in [Backup, Restore, and Out-of-Band Recovery](../runbooks/backup-and-restore.md).
 
 ### Recovery Procedure
-1. **Bootstrap Flux**: Run `scripts/bootstrap_flux.sh` on new cluster
-2. **Restore sealed-secrets key**: Apply backup to enable secret decryption
-3. **Wait for reconciliation**: Flux rebuilds entire cluster state from Git
-4. **Restore PVs**: Restore application data from backups if needed
-5. **Validate**: Check all applications are running and healthy
+1. **Recover access**: Use the pre-verified out-of-band path that does not depend
+   on the Kubernetes Tailscale Operator.
+2. **Bootstrap Flux**: Run `scripts/bootstrap_flux.sh` on a new cluster only when
+   the documented recovery design calls for a rebuild.
+3. **Restore the Sealed Secrets key**: Use the tested encrypted backup procedure.
+4. **Wait for reconciliation**: Flux rebuilds declarative controllers and workloads
+   from Git.
+5. **Restore application data**: Use the specific, tested backup procedure for each
+   backup-required workload.
+6. **Validate**: Check Flux readiness, access-plane resources, applications, and data
+   integrity without exposing credentials in logs.
 
 ### Key Recovery Points
 - **Flux bootstrap**: Restores all controllers and infrastructure

--- a/docs/ci/merge-and-automerge-policy.md
+++ b/docs/ci/merge-and-automerge-policy.md
@@ -1,0 +1,76 @@
+# Pull-request-only merge and auto-merge policy
+
+## Purpose
+
+Every normal repository change follows **branch → pull request → native GitHub
+squash auto-merge**. This is a safety boundary for the GitOps control plane: a
+commit must first receive the applicable automated validation before Flux can
+reconcile it.
+
+The initial rollout deliberately uses the existing `@alecsg77` administrative
+identity for both the maintainer and coding agents. After the server-side ruleset
+migration, the ruleset—not identity separation—blocks direct updates to `main`.
+Until then, this remains an unmitigated repository-settings gap and agents must
+still follow the PR-only client policy. An administrator can alter repository
+settings only through a documented break-glass event.
+
+## Required agent flow
+
+1. Create or update a non-`main` branch.
+2. Push only that branch.
+3. Open or update a PR targeting `main`.
+4. Enable native auto-merge with:
+
+   ```bash
+   gh pr merge --auto --squash
+   ```
+
+5. Never use `--admin`, force-push `main`, or merge through a direct Git push.
+6. Observe the PR until `PR Gate / required` is successful and auto-merge has
+   completed. If it fails, correct the PR; do not bypass the ruleset.
+
+`CODEOWNERS` assigns the repository to `@alecsg77` for ownership visibility. No
+review approval is required in this first phase; the fail-closed automated gate
+is the merge condition.
+
+## Monorepo gate
+
+`PR Gate / required` is the only required status check after the repository
+ruleset is migrated. It always runs and:
+
+- performs baseline secret/YAML checks and the trusted critical-resource guard;
+- detects which domains changed;
+- runs only the GitOps, Helm, Coder, Actions/scripts, and Fission-spec validators
+  relevant to the PR;
+- fails when any applicable validator fails, is cancelled, or is unexpectedly
+  skipped;
+- accepts an intentionally skipped validator only when the change detector marked
+  that domain as not applicable.
+
+Do not add a separate required check with a generic name such as `gate`:
+required status contexts must remain unambiguous. During bootstrap, older
+path-filtered workflows remain diagnostic-only; remove them in a later PR only
+after the ruleset requires this fan-in context.
+
+## Bot update policy
+
+Renovate and Dependabot use PR-based auto-merge and are subject to the same
+ruleset and `PR Gate / required` result. During the rollout, broad Renovate
+auto-merge is paused. It may be restored only for demonstrated R0 updates after
+the gate is active; major upgrades and changes that affect controllers, CRDs,
+stateful workloads, storage, Tailscale, or the protected GitOps control plane
+remain outside the automatic R0 category.
+
+## Break-glass
+
+A defective gate may be removed **temporarily** from the ruleset by the
+repository owner only. The repair still occurs in a PR, with all applicable
+validators run and recorded manually before merge. Restore the rule immediately
+and add an incident note to issue #87. Never restore a permanent administrator
+bypass or use a direct push as an emergency shortcut.
+
+## Related documentation
+
+- [PR validation](pr-validation.md)
+- [Destructive GitOps changes](../runbooks/destructive-gitops-change.md)
+- [GitHub break-glass](../runbooks/github-break-glass.md)

--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -3,6 +3,48 @@
 This document describes the GitHub Actions workflows that validate pull requests before merge.
 See `AGENTS.md` for the full command reference used by these workflows.
 
+## Current merge boundary
+
+The repository is moving to one always-present monorepo workflow:
+**`PR Gate / required`**. It detects the paths changed by a PR, runs baseline and
+applicable domain validators, and fails closed when a selected validator does not
+succeed. The ruleset requires this one context rather than path-filtered workflow
+contexts.
+
+The legacy path-filtered workflows remain temporarily for diagnostic continuity
+while the ruleset is migrated, but they are not merge requirements. Do not add
+their individual job names as additional required checks; once the GitHub ruleset
+requires `PR Gate / required`, they can be retired in a follow-up PR. See [Merge
+and auto-merge policy](merge-and-automerge-policy.md) for the agent flow and
+[Destructive GitOps changes](../runbooks/destructive-gitops-change.md) for the R2
+procedure.
+
+## `PR Gate` fan-in behavior
+
+The target ruleset configuration is intentionally enabled only after this workflow
+has reached the default branch and passed a test PR. Until that server-side step is
+complete, the workflow is diagnostic and repository policy still requires agents to
+use PRs and native auto-merge voluntarily.
+
+`pr-gate.yml` is loaded from the trusted default branch with
+`pull_request_target`. It checks out the proposed head SHA only as data, uses
+read-only permissions, disables persistent checkout credentials, and does not use
+production secrets or mutate the cluster. Its jobs are:
+
+- **baseline** — trusted YAML configuration, YAML parsing, bare-Secret rejection,
+  and gitleaks;
+- **critical** — the trusted-base rendered-diff guard, including root-composition,
+  dependency, remote-base, R1/R2, and intent checks;
+- **GitOps, Helm, Coder, Actions/scripts, functions** — conditional validators;
+- **required** — the only status context configured in the ruleset. It fails if a
+  selected validator fails, is cancelled, or unexpectedly skips.
+
+A change to a Tier 0 enforcement path—workflow, guard, guard policy,
+`.github/actionlint.yaml`, or `CODEOWNERS`—selects every domain validator. This
+prevents an enforcement-boundary change from being validated by only its own
+narrow job. The Coder validator consequently validates every current template when
+Tier 0 changes select that domain.
+
 ## Level 1 — repository-wide checks (always run on every PR)
 
 ### YAML lint (`pr-lint-yaml.yml`)

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -16,6 +16,11 @@ This directory contains step-by-step procedures for routine operational tasks. E
 - **[tsidp OIDC for Headlamp](tsidp-sso.md)** - Per-user Headlamp OIDC and Kubernetes RBAC rollout
 - **[Gitless ResourceSet Image Automation](resourceset-image-automation.md)** - Gitless workload image updates, safety gates, and rollback pins
 
+### Change Safety and Recovery
+- **[Destructive GitOps Changes](destructive-gitops-change.md)** - R2 classification, required two-PR removal sequence, backup evidence, and rollback
+- **[Backup, Restore, and Out-of-Band Recovery](backup-and-restore.md)** - Required recovery contract, restore drills, and no-private-details policy
+- **[GitHub Merge-Control Break-Glass](github-break-glass.md)** - Repairing a failed required gate without direct pushes
+
 ### Cluster Operations
 - **[Flux Web UI with tsidp OIDC](flux-web-ui.md)** - Private-domain Flux dashboard, OIDC client sealing, read-only RBAC, and rollback
 - **[Migrating Flux to Flux Operator](flux-operator-migration.md)** - Staged, zero-downtime migration and optional internal MCP rollout

--- a/docs/runbooks/backup-and-restore.md
+++ b/docs/runbooks/backup-and-restore.md
@@ -1,0 +1,73 @@
+# Backup, restore, and out-of-band recovery contract
+
+> **Status: design and verification work is tracked in issue #90.** This runbook
+> intentionally does not claim that a local PVC named `pvc-backups` is an
+> off-cluster backup or that any restore drill has completed.
+
+## Required contract before an R2 data change
+
+For every persistent workload, record:
+
+- classification: ephemeral, reconstructible, or backup-required;
+- owner and data location;
+- RPO and RTO;
+- encrypted off-cluster destination and retention;
+- backup command/automation and monitoring;
+- restore command and validation;
+- date and result of the last restore drill.
+
+The initial inventory must cover Sealed Secrets key material, tsidp state,
+application databases/PVCs, Arkham local PVs, Coder/RomM state, and monitoring
+data. The exact host and storage endpoint details stay in local operational
+documentation, not in this public repository.
+
+## Sealed Secrets key backup
+
+The Sealed Secrets private key is needed to decrypt every committed
+`SealedSecret`. Export it only to a controlled temporary directory, encrypt it
+before any persistent write, verify the encrypted artifact can be decrypted by an
+authorized custodian, and securely remove the plaintext temporary export.
+
+Do not commit the export, its passphrase, or the encrypted backup into this
+repository. Follow the updated procedure in [Secret Management](../security/secret-management.md).
+
+## Out-of-band recovery
+
+Before relying on a Tailscale-managed access route, verify a recovery path that
+does not depend on the Kubernetes Tailscale Operator. Record the test date,
+operator, and outcome in the private operational log. Keep console/LAN/host
+identifiers and credentials outside Git.
+
+## Detection and post-merge audit
+
+The repository includes two detective controls that complement the preventive
+ruleset and trusted-base guard:
+
+- `.github/workflows/audit-main-integrity.yml` fails when a new `main` commit has
+  no GitHub pull-request association.
+- `monitoring/configs/flux-safety-rules.yaml` alerts for non-ready bootstrap
+  Kustomizations/critical HelmReleases and a reduced Flux/Tailscale recovery
+  inventory.
+
+Treat either signal as an incident. Preserve the current Git revision, inspect
+Flux status through a surviving administrative path, and use [Destructive GitOps
+Changes](destructive-gitops-change.md) or [GitHub Merge-Control
+Break-Glass](github-break-glass.md) as appropriate. These controls cannot prove
+an out-of-band channel exists: the channel's test date, operator, and result must
+remain in the private operational log.
+
+## Restore drill
+
+A restore drill must be carried out before any destructive storage migration:
+
+1. Restore a representative backup into an isolated target or approved recovery
+   window.
+2. Validate application integrity and access without exposing secrets in logs.
+3. Measure actual recovery time and compare it with the workload RTO.
+4. Record gaps, rotate exposed credentials if applicable, and update the contract.
+
+## Related documentation
+
+- [Secret Management](../security/secret-management.md)
+- [Destructive GitOps changes](destructive-gitops-change.md)
+- [HelmRelease recovery](helm-release-recovery.md)

--- a/docs/runbooks/destructive-gitops-change.md
+++ b/docs/runbooks/destructive-gitops-change.md
@@ -1,0 +1,82 @@
+# Destructive GitOps change procedure
+
+## Purpose
+
+Flux pruning is intentional: a resource removed from a reconciled source can be
+removed from the cluster. This procedure prevents an accidental source or
+ownership change from becoming an unreviewed destructive action.
+
+Use it whenever `PR Gate / required` classifies a proposal as **R2**, including a
+critical resource deletion/rename, a PVC identity/storage change, or a change to
+a protected Flux path, source, pruning, deletion policy, or dependency boundary.
+
+## Preconditions
+
+- The change is made on a branch and proposed by PR; never directly on `main`.
+- The target resource appears in `.github/critical-resources.yaml`.
+- Backup and rollback evidence is real, non-secret, and refers to a documented
+  artefact or known-good Git revision.
+- For persistent data, the backup/restore contract in issue #90 has been
+  completed and the restore has been exercised. Until then, do not make an R2
+  storage change.
+
+## Two-PR R2 sequence
+
+### PR 1 — declare intent / remove protection when required
+
+Create `.github/critical-removal-intents/<resource-id-with-slashes-as-__>.yaml`:
+
+```yaml
+resource: tailscale/connector
+operation: remove
+backup: "Not applicable: Connector has no persistent data; see recovery commit <sha>."
+rollback: "Restore connector.yaml from commit <sha>."
+```
+
+Use `operation: remove` when the later PR deletes a critical resource. For a
+protected R2 field change that retains the resource—such as a CRD schema or PVC
+storage field—use `operation: change` and make the backup/rollback evidence
+specific to that change.
+
+For resources carrying `kustomize.toolkit.fluxcd.io/prune: disabled`, a removal
+preparation PR also removes that annotation. It does **not** remove the resource.
+Let native auto-merge complete only after `PR Gate / required` succeeds.
+
+### PR 2 — consume intent and perform the exact R2 operation
+
+In a later branch/PR, remove the intent file and perform exactly its matching
+R2 operation. For `remove`, delete the target resource too; for `change`, modify
+the intended protected resource. The trusted-base guard reports every protected
+field that changed, compares the already-merged intent against the policy, and
+consumes it so it cannot authorize a future unrelated operation.
+
+The five root bootstrap files and the fixed `clusters/kyrion/kustomization.yaml`
+resource list are never removable through this procedure. Escalate those cases to
+a separately approved recovery design.
+
+## Validation
+
+Before enabling auto-merge:
+
+1. Render every affected Kustomize/Flux target locally.
+2. Confirm the critical guard shows the expected R2 operation and no unexpected
+   resource identities disappear.
+3. For access-plane changes, use the documented non-sensitive validation from a
+   surviving administrative path.
+4. For data changes, verify the backup exists and the documented restore has been
+   tested before the production change.
+5. After reconciliation, check the affected Flux Kustomization and workload are
+   Ready; do not delete live Kubernetes resources to force a result.
+
+## Rollback
+
+Revert the merged PR through a new PR and use native auto-merge. Restore a
+resource from its documented known-good Git revision; restore persistent data
+only through its tested backup procedure. Do not manually delete Flux CRDs,
+Namespaces, or Secrets as a shortcut.
+
+## Related documentation
+
+- [Pull-request-only merge policy](../ci/merge-and-automerge-policy.md)
+- [Backup and restore](backup-and-restore.md)
+- [HelmRelease recovery](helm-release-recovery.md)

--- a/docs/runbooks/github-break-glass.md
+++ b/docs/runbooks/github-break-glass.md
@@ -1,0 +1,42 @@
+# GitHub merge-control break-glass
+
+## Purpose
+
+This runbook repairs a broken repository safety control without normalizing direct
+pushes to `main`.
+
+## When it is allowed
+
+Use break-glass only when `PR Gate / required` is itself defective or unavailable
+and blocks the repair PR. It is not a response to a failed application deployment,
+a slow reconciliation, or an inconvenient validation result.
+
+## Procedure
+
+1. Record the incident in issue #87 with the failing check, commit SHA, time, and
+   intended repair. Do not include private network identifiers or credentials.
+2. In GitHub repository Rules, remove **only** `PR Gate / required` from the
+   `Protection` ruleset. Keep pull-request-only, deletion, and non-fast-forward
+   rules active and do not add a bypass actor.
+3. Open a PR that repairs the gate. Run every applicable validator locally and
+   attach the exact commands/results to the PR.
+4. Enable native squash auto-merge. Do not use `--admin` and do not push directly
+   to `main`.
+5. Immediately restore `PR Gate / required` in the ruleset after the repair is on
+   `main`.
+6. Open a harmless follow-up PR to confirm the repaired gate runs and succeeds.
+7. Update issue #87 with the restoration time and validation result.
+
+## If GitHub itself is unavailable
+
+Use the pre-verified out-of-band server/cluster recovery channel documented
+outside this public repository. Restore a known-good Git state through a PR once
+GitHub access is back. Do not document private hostnames, addresses, or credentials
+in this runbook.
+
+## Exit criteria
+
+- The ruleset again requires PRs and `PR Gate / required`.
+- The bypass list is empty.
+- A test PR runs the gate from the current default branch.
+- The incident record identifies why break-glass was used and when it ended.

--- a/docs/runbooks/helm-release-recovery.md
+++ b/docs/runbooks/helm-release-recovery.md
@@ -143,6 +143,16 @@ helm rollback <name> <revision> -n <namespace>
 # Update HelmRelease in Git to prevent re-upgrade
 ```
 
+#### Destructive-operation checkpoint
+
+Before deleting a HelmRelease, uninstalling a release, or deleting a PVC:
+
+1. Confirm the action is represented by a Git PR, not a direct cluster mutation.
+2. For a critical/R2 resource, follow [Destructive GitOps Changes](destructive-gitops-change.md).
+3. Verify and record a tested backup/restore reference for persistent data. If no
+   tested restore exists, stop and complete the backup contract first.
+4. Preserve the current known-good Git revision for rollback.
+
 #### Option D: Delete and Recreate (Last Resort)
 
 ```bash
@@ -186,9 +196,9 @@ kubectl describe pvc <mongodb-pvc> -n ai
 # 2. Delete pod to force restart
 kubectl delete pod -n ai <mongodb-pod>
 
-# 3. If PV corrupted, delete PVC and recreate
-kubectl delete pvc <mongodb-pvc> -n ai
-# HelmRelease will recreate PVC automatically
+# 3. If PV corruption is confirmed, do NOT delete the PVC immediately.
+# Follow docs/runbooks/destructive-gitops-change.md and restore from the tested
+# backup procedure. PVC deletion/recreation without a verified restore can lose data.
 
 # 4. Check MongoDB container image
 # Verify image exists and is pullable

--- a/docs/runbooks/tsidp-sso.md
+++ b/docs/runbooks/tsidp-sso.md
@@ -294,6 +294,15 @@ After Flux reconciles the Headlamp change:
 
 If Headlamp authenticates successfully but sees `forbidden` errors, inspect the `tsidp-viewer` binding and verify that the user token includes the raw `groups: ["viewer"]` claim. If Headlamp receives `401 Unauthorized`, verify the issuer URL and that the token audience equals the Headlamp client ID configured in k3s.
 
+## Persistent-state protection
+
+`tsidp` stores issuer, signing, registration, and refresh-token state in its PVC.
+Before any upgrade, rollback, Helm uninstall, or PVC-related operation that could
+replace that state, verify a tested backup and restore reference. Do not treat a
+local application PVC as an off-cluster backup. For destructive changes, follow
+[Destructive GitOps Changes](destructive-gitops-change.md) and the
+[Backup, Restore, and Out-of-Band Recovery](backup-and-restore.md) contract.
+
 ## Rollback
 
 ### Headlamp-only failure

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -47,10 +47,10 @@ rg -n 'password|secret|token|apikey|bearer' diagnostics/
 
 ### Key Backup
 
-```bash
-# Backup sealed-secrets key (quarterly)
-kubectl get secret -n sealed-secrets-system sealed-secrets-key -o yaml > sealed-secrets-backup.yaml
-```
+Export the Sealed Secrets key only to a mode-0700 temporary directory, encrypt it
+before persistent storage, verify an authorized custodian can decrypt it, and
+remove the plaintext export. See the full [Secret Management Guide](secret-management.md)
+and [Backup, Restore, and Out-of-Band Recovery](../runbooks/backup-and-restore.md).
 
 ## Security Principles
 

--- a/docs/security/secret-management.md
+++ b/docs/security/secret-management.md
@@ -198,12 +198,31 @@ spec:
 
 ### Backup Procedure (Quarterly Recommended)
 
-```bash
-# Export sealed-secrets keys (TLS cert and key)
-kubectl get secret -n sealed-secrets-system sealed-secrets-key -o yaml > sealed-secrets-backup.yaml
+Export only to a controlled temporary directory, encrypt before any persistent
+write, and remove the plaintext export immediately after verifying the encrypted
+artifact. Keep the output path and recipient/key reference in private operational
+documentation, not in Git.
 
-# Store securely (encrypted, off-cluster location)
-# Options: password manager, encrypted USB drive, secure cloud storage
+```bash
+set -euo pipefail
+umask 077
+tmpdir="$(mktemp -d)"
+trap 'rm -rf -- "$tmpdir"' EXIT
+
+# The plaintext exists only inside the mode-0700 temporary directory.
+kubectl get secret -n sealed-secrets-system sealed-secrets-key -o yaml \
+  > "$tmpdir/sealed-secrets-key.yaml"
+
+# Example: use the approved off-cluster encryption recipient from the private
+# operations record. Do not commit either artifact or recipient details.
+age --encrypt --recipient "<approved-recipient>" \
+  --output "$tmpdir/sealed-secrets-key.yaml.age" \
+  "$tmpdir/sealed-secrets-key.yaml"
+
+# Verify decryptability with an authorized custodian before storing the encrypted
+# artifact in the approved off-cluster location.
+age --decrypt --identity "<authorized-identity>" \
+  "$tmpdir/sealed-secrets-key.yaml.age" >/dev/null
 ```
 
 **CRITICAL**: The sealed-secrets private key is required to decrypt all SealedSecret resources. Loss of this key means **permanent loss of all encrypted secrets**.

--- a/docs/troubleshooting/implementation-status.md
+++ b/docs/troubleshooting/implementation-status.md
@@ -1,9 +1,12 @@
 # Implementation Status
 
-**Date**: 2025-01-24  
-**Status**: ✅ Complete
+**Date**: 2026-08-12
+**Status**: Historical implementation record; active safety/recovery work is tracked in [#87](https://github.com/alecsg77/elysium/issues/87).
 
-Web-based troubleshooting system implementation for cluster issue resolution via GitHub Issues and Copilot agents.
+This document records the original web-based troubleshooting implementation. It is
+not the source of truth for current PR-only merge controls, destructive GitOps
+protection, or backup/restore readiness; see the current runbooks under
+`docs/runbooks/`.
 
 ## What Was Built
 

--- a/docs/troubleshooting/known-issues.md
+++ b/docs/troubleshooting/known-issues.md
@@ -2,7 +2,11 @@
 
 This knowledge base documents common cluster problems, their symptoms, root causes, and verified resolutions.
 
-**Last Updated**: 2025-01-24
+**Last Updated**: 2026-08-12
+
+> Merge-control and recovery work after the August 11, 2026 Flux root-composition
+> incident is tracked in issue #87. See the [GitHub break-glass](../runbooks/github-break-glass.md)
+> and [destructive GitOps](../runbooks/destructive-gitops-change.md) runbooks.
 
 ## How to Use
 

--- a/infrastructure/configs/flux-instance/release.yaml
+++ b/infrastructure/configs/flux-instance/release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: flux-instance
   namespace: flux-system
+  annotations:
+    # Keep the generated FluxInstance reconciler when a parent inventory changes.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   dependsOn:
     - name: flux-operator

--- a/infrastructure/configs/networking/ts-ingress-arkham.yaml
+++ b/infrastructure/configs/networking/ts-ingress-arkham.yaml
@@ -3,6 +3,9 @@ kind: Ingress
 metadata:
   name: arkham
   namespace: kube-system
+  annotations:
+    # Retain the recovery ingress while its parent reconciliation is repaired.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   ingressClassName: tailscale
   defaultBackend:

--- a/infrastructure/configs/tailscale/connector.yaml
+++ b/infrastructure/configs/tailscale/connector.yaml
@@ -3,5 +3,8 @@ kind: Connector
 metadata:
   name: connector
   namespace: tailscale
+  annotations:
+    # Retain recovery egress if its parent source is accidentally pruned.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   exitNode: true

--- a/infrastructure/configs/tailscale/default-proxy-class.yaml
+++ b/infrastructure/configs/tailscale/default-proxy-class.yaml
@@ -3,6 +3,9 @@ kind: ProxyClass
 metadata:
   name: default
   namespace: tailscale
+  annotations:
+    # Retain the default proxy policy used by recovery access resources.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   metrics:
     enable: true

--- a/infrastructure/configs/tailscale/dns.yaml
+++ b/infrastructure/configs/tailscale/dns.yaml
@@ -3,6 +3,9 @@ kind: DNSConfig
 metadata:
   name: ts-dns
   namespace: tailscale
+  annotations:
+    # Keep Tailscale DNS available while repairing parent reconciliation.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   nameserver:
     image:

--- a/infrastructure/configs/tailscale/homeassistant-egress-service.yaml
+++ b/infrastructure/configs/tailscale/homeassistant-egress-service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: homeassistant-egress
   namespace: kube-system
   annotations:
+    # Preserve the egress service if the source inventory is accidentally pruned.
+    kustomize.toolkit.fluxcd.io/prune: disabled
     tailscale.com/proxy-group: tsidp-egress
     tailscale.com/tailnet-fqdn: homeassistant.${ts_net}
 spec:

--- a/infrastructure/configs/tailscale/tsidp-egress-proxygroup.yaml
+++ b/infrastructure/configs/tailscale/tsidp-egress-proxygroup.yaml
@@ -2,6 +2,9 @@ apiVersion: tailscale.com/v1alpha1
 kind: ProxyGroup
 metadata:
   name: tsidp-egress
+  annotations:
+    # Retain egress routing required by the authentication access plane.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   type: egress
   proxyClass: default

--- a/infrastructure/configs/tailscale/tsidp-egress-service.yaml
+++ b/infrastructure/configs/tailscale/tsidp-egress-service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: tsidp-egress
   namespace: kube-system
   annotations:
+    # Preserve the egress service if the source inventory is accidentally pruned.
+    kustomize.toolkit.fluxcd.io/prune: disabled
     tailscale.com/proxy-group: tsidp-egress
     tailscale.com/tailnet-fqdn: idp.${ts_net}
 spec:

--- a/infrastructure/controllers/flux-operator/flux-web-client-sealed-secret.yaml
+++ b/infrastructure/controllers/flux-operator/flux-web-client-sealed-secret.yaml
@@ -4,6 +4,9 @@ kind: SealedSecret
 metadata:
   name: flux-web-client
   namespace: flux-system
+  annotations:
+    # Preserve Flux Web OIDC material while restoring the control plane.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   encryptedData:
     client-id: AgConL9xnrHiLvD76C33APUNV+WETT2CKRAQGA5gP9Ixg7DbB20+DpXMwXxJv5vAR3jQMBRM8FxW8Y45qw6l/A9scuQHLUpYDUJf/l4/rGkFU4sxLsVHsNquYEYB43djmOzYbNmDtOqhTsD9QsQ+p2nlu487/uOWc/9EWFQjPjjD5NkfLQ/Vi0VbmrLm4K39BdRs902q1fHXdpUgzt6V7JodtTgYo1E80ETUZCWvjyxFaDAwKeF5XOQ4jjcTLL4ZZoh0zSLzfuNwkrd77TWbolTWIuSGXY3Bol1eUjwidZuQWUgVHO6H7VLCV00tt0o+kZSAiRjAZgeaEloYsk0ujSukewSvw9FHU5IZtFcP+q4v3v4nQkGNqWiivKujCwmrn3sosaM3IJeMecuIWs5uZdrFTTpYKWbsMiFnlCX3oqSprvC+tDdY3on4PMH8UhRDp6oaeKH+ZW2Fdys1IQ+43ZV0LIpJ1M5v3FpWsa1tew73WxqkIvpewCeGPgjFJ91C8Rggd0fNh9wCPM3Un20cOASAn47ww+/tGyIpoz7s+L8cw7ms+JPDQecih1LzAcIC+UQQ/jOG8h13h3Qjm9maXlVw11G1rDH9rBRv3/K/ajBxOddFpXQQcnvHdP0BxRUG6veFS90TQKoLeYwwsZCY6Asn/Iz6h9yU0ry/f9yvKM91UHv4mTk1kvlj7qG5UoXlfRWKVEpknilfFof5JzooZeb5Hn676fwcCfSdkZOZWdCC+A==

--- a/infrastructure/controllers/flux-operator/release.yaml
+++ b/infrastructure/controllers/flux-operator/release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: flux-operator
   namespace: flux-system
+  annotations:
+    # Preserve the Flux control-plane operator if a parent inventory is damaged.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   interval: 1h
   timeout: 10m

--- a/infrastructure/controllers/sealed-secrets/release.yaml
+++ b/infrastructure/controllers/sealed-secrets/release.yaml
@@ -4,6 +4,9 @@ kind: HelmRelease
 metadata:
   name: sealed-secrets
   namespace: flux-system
+  annotations:
+    # Keep the controller required to recover all encrypted Git secrets.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   chart:
     spec:

--- a/infrastructure/controllers/system-upgrade/controller.yaml
+++ b/infrastructure/controllers/system-upgrade/controller.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: flux-system
 spec:
   interval: 24h
+  # Keep controller source and the vendored Plan CRD on one reviewed release.
+  # Upgrade this tag only through the R2 two-PR procedure.
   ref:
-    semver: '*'
+    tag: v0.20.1
   url: https://github.com/rancher/system-upgrade-controller.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/infrastructure/controllers/system-upgrade/crd.yaml
+++ b/infrastructure/controllers/system-upgrade/crd.yaml
@@ -1,0 +1,1306 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: plans.upgrade.cattle.io
+spec:
+  group: upgrade.cattle.io
+  names:
+    kind: Plan
+    listKind: PlanList
+    plural: plans
+    singular: plan
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.upgrade.image
+      name: Image
+      type: string
+    - jsonPath: .spec.channel
+      name: Channel
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Complete')].status
+      name: Complete
+      type: string
+    - jsonPath: .status.conditions[?(@.message!='')].message
+      name: Message
+      type: string
+    - jsonPath: .status.applying
+      name: Applying
+      priority: 10
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Plan represents a set of Jobs to apply an upgrade (or other operation)
+          to set of Nodes.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PlanSpec represents the user-configurable details of a Plan.
+            properties:
+              channel:
+                description: A URL that returns HTTP 302 with the last path element
+                  of the value returned in the Location header assumed to be an image
+                  tag (after munging "+" to "-").
+                type: string
+              concurrency:
+                description: The maximum number of concurrent nodes to apply this
+                  update on.
+                format: int64
+                type: integer
+              cordon:
+                description: |-
+                  If Cordon is true, the node is cordoned before the upgrade container is run.
+                  If drain is specified, the value for cordon is ignored, and the node is cordoned.
+                  If neither drain nor cordon are specified and the node is marked as schedulable=false it will not be marked as schedulable=true when the Job completes.
+                type: boolean
+              drain:
+                description: Configuration for draining nodes prior to upgrade. If
+                  left unspecified, no drain will be performed.
+                properties:
+                  deleteEmptydirData:
+                    type: boolean
+                  deleteLocalData:
+                    type: boolean
+                  disableEviction:
+                    type: boolean
+                  force:
+                    type: boolean
+                  gracePeriod:
+                    format: int32
+                    type: integer
+                  ignoreDaemonSets:
+                    type: boolean
+                  podSelector:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  skipWaitForDeleteTimeout:
+                    type: integer
+                  timeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      If a string, this is passed through directly to the `kubectl drain` command.
+                      If an int, this represents the duration as a count of nanoseconds, and will be converted to a duration string when passed to the `kubectl drain` command.
+                    x-kubernetes-int-or-string: true
+                type: object
+              exclusive:
+                description: Jobs for exclusive plans cannot be run alongside any
+                  other exclusive plan.
+                type: boolean
+              imagePullSecrets:
+                description: Image Pull Secrets, used to pull images for the Job.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              jobActiveDeadlineSecs:
+                description: |-
+                  Sets ActiveDeadlineSeconds on Jobs generated to apply this Plan.
+                  If the Job does not complete within this time, the Plan will stop processing until it is updated to trigger a redeploy.
+                  If set to 0, Jobs have no deadline. If not set, the controller default value is used.
+                format: int64
+                type: integer
+              nodeSelector:
+                description: Select which nodes this plan can be applied to.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              postCompleteDelay:
+                description: Time after a Job for one Node is complete before a new
+                  Job will be created for the next Node.
+                type: string
+              postCompleteLabels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Label key-value pairs to apply to a node when the job for this plan completes successfully.
+                  Values may contain `$(LATEST_HASH)` or `$(LATEST_VERSION)`, which will be expanded from the plan status.
+                type: object
+              prepare:
+                description: The prepare init container, if specified, is run before
+                  cordon/drain which is run before the upgrade container.
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    items:
+                      type: string
+                    type: array
+                  envFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: |-
+                            Optional text to prepend to the name of each environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  envs:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Image name. If the tag is omitted, the value from
+                      .status.latestVersion will be used.
+                    type: string
+                  securityContext:
+                    description: |-
+                      SecurityContext holds security configuration that will be applied to a container.
+                      Some fields are present in both SecurityContext and PodSecurityContext.  When both
+                      are set, the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                          overrides the pod's appArmorProfile.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile loaded on the node that should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must match the loaded name of the profile.
+                              Must be set if and only if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of AppArmor profile will be applied.
+                              Valid options are:
+                                Localhost - a profile pre-loaded on the node.
+                                RuntimeDefault - the container runtime's default profile.
+                                Unconfined - no AppArmor enforcement.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default value is Default which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  volumes:
+                    items:
+                      description: HostPath volume to mount into the pod
+                      properties:
+                        destination:
+                          description: Path to mount the Volume at within the Pod.
+                          type: string
+                        name:
+                          description: Name of the Volume as it will appear within
+                            the Pod spec.
+                          type: string
+                        source:
+                          description: Path on the host to mount.
+                          type: string
+                      required:
+                      - destination
+                      - name
+                      - source
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
+              priorityClassName:
+                description: Priority Class Name of Job, if specified.
+                type: string
+              secrets:
+                description: Secrets to be mounted into the Job Pod.
+                items:
+                  description: SecretSpec describes a Secret to be mounted for prepare/upgrade
+                    containers.
+                  properties:
+                    defaultMode:
+                      description: Mode to mount the Secret volume with.
+                      format: int32
+                      type: integer
+                    ignoreUpdates:
+                      description: If set to true, the Secret contents will not be
+                        hashed, and changes to the Secret will not trigger new application
+                        of the Plan.
+                      type: boolean
+                    name:
+                      description: Secret name
+                      type: string
+                    path:
+                      description: Path to mount the Secret volume within the Pod.
+                      type: string
+                  required:
+                  - name
+                  - path
+                  type: object
+                type: array
+              serviceAccountName:
+                description: The service account for the pod to use. As with normal
+                  pods, if not specified the default service account from the namespace
+                  will be assigned.
+                type: string
+              tolerations:
+                description: |-
+                  Specify which node taints should be tolerated by pods applying the upgrade.
+                  Anything specified here is appended to the default of:
+                  - `{key: node.kubernetes.io/unschedulable, effect: NoSchedule, operator: Exists}`
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              upgrade:
+                description: The upgrade container; must be specified.
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    items:
+                      type: string
+                    type: array
+                  envFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: |-
+                            Optional text to prepend to the name of each environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  envs:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Image name. If the tag is omitted, the value from
+                      .status.latestVersion will be used.
+                    type: string
+                  securityContext:
+                    description: |-
+                      SecurityContext holds security configuration that will be applied to a container.
+                      Some fields are present in both SecurityContext and PodSecurityContext.  When both
+                      are set, the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                          overrides the pod's appArmorProfile.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile loaded on the node that should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must match the loaded name of the profile.
+                              Must be set if and only if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of AppArmor profile will be applied.
+                              Valid options are:
+                                Localhost - a profile pre-loaded on the node.
+                                RuntimeDefault - the container runtime's default profile.
+                                Unconfined - no AppArmor enforcement.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default value is Default which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  volumes:
+                    items:
+                      description: HostPath volume to mount into the pod
+                      properties:
+                        destination:
+                          description: Path to mount the Volume at within the Pod.
+                          type: string
+                        name:
+                          description: Name of the Volume as it will appear within
+                            the Pod spec.
+                          type: string
+                        source:
+                          description: Path on the host to mount.
+                          type: string
+                      required:
+                      - destination
+                      - name
+                      - source
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
+              version:
+                description: Providing a value for version will prevent polling/resolution
+                  of the channel if specified.
+                type: string
+              window:
+                description: |-
+                  A time window in which to execute Jobs for this Plan.
+                  Jobs will not be generated outside this time window, but may continue executing into the window once started.
+                properties:
+                  days:
+                    description: Days that this time window is valid for
+                    items:
+                      enum:
+                      - "0"
+                      - su
+                      - sun
+                      - sunday
+                      - "1"
+                      - mo
+                      - mon
+                      - monday
+                      - "2"
+                      - tu
+                      - tue
+                      - tuesday
+                      - "3"
+                      - we
+                      - wed
+                      - wednesday
+                      - "4"
+                      - th
+                      - thu
+                      - thursday
+                      - "5"
+                      - fr
+                      - fri
+                      - friday
+                      - "6"
+                      - sa
+                      - sat
+                      - saturday
+                      type: string
+                    minItems: 1
+                    type: array
+                  endTime:
+                    description: End of the time window.
+                    type: string
+                  startTime:
+                    description: Start of the time window.
+                    type: string
+                  timeZone:
+                    description: Time zone for the time window; if not specified UTC
+                      will be used.
+                    type: string
+                type: object
+            required:
+            - upgrade
+            type: object
+          status:
+            description: PlanStatus represents the resulting state from processing
+              Plan events.
+            properties:
+              applying:
+                description: List of Node names that the Plan is currently being applied
+                  on.
+                items:
+                  type: string
+                type: array
+              conditions:
+                description: |-
+                  `LatestResolved` indicates that the latest version as per the spec has been determined.
+                  `Validated` indicates that the plan spec has been validated.
+                  `Complete` indicates that the latest version of the plan has completed on all selected nodes. If any Jobs for the Plan fail to complete, this condition will remain false, and the reason and message will reflect the source of the error.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of cluster condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              latestHash:
+                description: The hash of the most recently applied plan .spec.
+                type: string
+              latestVersion:
+                description: The latest version, as resolved from .spec.version, or
+                  the channel server.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/infrastructure/controllers/system-upgrade/kustomization.yaml
+++ b/infrastructure/controllers/system-upgrade/kustomization.yaml
@@ -1,6 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# Vendored from rancher/system-upgrade-controller v0.20.1 release asset
+# `crd.yaml`, verified against the upstream SHA-256:
+# 68a2e6b786dc3a3d47f0ac557b06833d2f773d801f482f43d37c7e819309c656.
+# Keep the CRD local and versioned so Flux/CI never fetches mutable `releases/latest`.
+# Upgrade its provenance deliberately with the controller source and CRD policy.
 resources:
-  - https://github.com/rancher/system-upgrade-controller/releases/latest/download/crd.yaml
+  - crd.yaml
   - controller.yaml

--- a/infrastructure/controllers/tailscale-operator/release.yaml
+++ b/infrastructure/controllers/tailscale-operator/release.yaml
@@ -4,6 +4,9 @@ kind: HelmRelease
 metadata:
   name: tailscale-operator
   namespace: flux-system
+  annotations:
+    # Preserve the operator that provides the cluster recovery access plane.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   chart:
     spec:

--- a/infrastructure/controllers/tsidp/release.yaml
+++ b/infrastructure/controllers/tsidp/release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: tsidp
   namespace: tailscale
+  annotations:
+    # Preserve tsidp's stateful authentication service during parent recovery.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   releaseName: tsidp
   dependsOn:

--- a/monitoring/configs/flux-safety-rules.yaml
+++ b/monitoring/configs/flux-safety-rules.yaml
@@ -1,0 +1,82 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: flux-safety
+  labels:
+    app.kubernetes.io/part-of: flux
+    app.kubernetes.io/component: monitoring
+spec:
+  groups:
+    - name: flux-gitops-safety
+      rules:
+        - alert: FluxBootstrapKustomizationNotReady
+          expr: >-
+            gotk_resource_info{customresource_group="kustomize.toolkit.fluxcd.io",customresource_kind="Kustomization",exported_namespace="flux-system",name=~"apps|infra-controllers|infra-configs|monitoring-controllers|monitoring-configs",ready!="True"} == 1
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Critical Flux bootstrap Kustomization is not Ready
+            description: >-
+              Flux Kustomization {{ $labels.name }} has been non-ready for ten minutes.
+              Follow the destructive GitOps and GitHub break-glass runbooks; do not
+              mutate the cluster directly to clear the alert.
+        - alert: FluxCriticalHelmReleaseNotReady
+          expr: >-
+            gotk_resource_info{customresource_group="helm.toolkit.fluxcd.io",customresource_kind="HelmRelease",name=~"flux-operator|flux-instance|sealed-secrets|tailscale-operator|tsidp",ready!="True"} == 1
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Critical Flux-managed HelmRelease is not Ready
+            description: >-
+              HelmRelease {{ $labels.exported_namespace }}/{{ $labels.name }} has
+              been non-ready for ten minutes. Preserve access and recovery state;
+              diagnose through Git and Flux status before any destructive action.
+        - alert: TailscaleAccessPlaneResourceNotReady
+          expr: >-
+            gotk_resource_info{customresource_group="tailscale.com",customresource_kind=~"Connector|DNSConfig|ProxyClass|ProxyGroup",ready!="True"} == 1
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Tailscale access-plane resource is not Ready
+            description: >-
+              Tailscale {{ $labels.customresource_kind }} {{ $labels.name }} has
+              been non-ready for ten minutes. Use the verified out-of-band path if
+              administrative connectivity is affected.
+        - alert: TailscaleCriticalResourceInventoryReduced
+          expr: >-
+            count(gotk_resource_info{customresource_group="tailscale.com",customresource_kind=~"Connector|DNSConfig|ProxyClass|ProxyGroup",name=~"connector|default|ts-dns|tsidp-egress"}) < 4
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Tailscale critical custom-resource inventory is reduced
+            description: >-
+              Fewer than four required Connector, ProxyClass, DNSConfig, and
+              ProxyGroup resources are observed. Investigate Git history and Flux
+              reconciliation through the out-of-band recovery path.
+        - alert: TailscaleRecoveryServiceInventoryReduced
+          expr: >-
+            count(kube_service_info{namespace="kube-system",service=~"tsidp-egress|homeassistant-egress"}) < 2
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Tailscale recovery Service inventory is reduced
+            description: >-
+              Fewer than two expected recovery egress Services are observed in
+              kube-system. Check the protected GitOps inventory before changing
+              Kubernetes resources directly.
+        - alert: TailscaleRecoveryIngressMissing
+          expr: >-
+            count(kube_ingress_info{namespace="kube-system",ingress="arkham"}) < 1
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Tailscale recovery ingress is missing
+            description: >-
+              The protected Arkham recovery Ingress is absent. Use out-of-band
+              access and recover its known-good Git state through a pull request.

--- a/monitoring/configs/kustomization.yaml
+++ b/monitoring/configs/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: monitoring
 resources:
   - podmonitor.yaml
   - grafana-mcp-monitor.yaml
+  - flux-safety-rules.yaml
   - resourceset-image-automation-rules.yaml
 
 configMapGenerator:

--- a/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml
+++ b/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml
@@ -34,6 +34,14 @@ kube-state-metrics:
           - resourcesets
           - resourcesetinputproviders
         verbs: ["list", "watch"]
+      - apiGroups:
+          - tailscale.com
+        resources:
+          - connectors
+          - dnsconfigs
+          - proxyclasses
+          - proxygroups
+        verbs: ["list", "watch"]
   customResourceState:
     enabled: true
     config:
@@ -58,6 +66,70 @@ kube-state-metrics:
                   suspended: [spec, suspend]
                   revision: [status, lastAppliedRevision]
                   source_name: [spec, sourceRef, name]
+          - groupVersionKind:
+              group: tailscale.com
+              version: v1alpha1
+              kind: Connector
+            metricNamePrefix: gotk
+            metrics:
+              - name: "resource_info"
+                help: "The current state of a Tailscale Connector resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [metadata, name]
+                labelsFromPath:
+                  exported_namespace: [metadata, namespace]
+                  ready: [status, conditions, "[type=ConnectorReady]", status]
+          - groupVersionKind:
+              group: tailscale.com
+              version: v1alpha1
+              kind: DNSConfig
+            metricNamePrefix: gotk
+            metrics:
+              - name: "resource_info"
+                help: "The current state of a Tailscale DNSConfig resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [metadata, name]
+                labelsFromPath:
+                  exported_namespace: [metadata, namespace]
+                  ready: [status, conditions, "[type=NameserverReady]", status]
+          - groupVersionKind:
+              group: tailscale.com
+              version: v1alpha1
+              kind: ProxyClass
+            metricNamePrefix: gotk
+            metrics:
+              - name: "resource_info"
+                help: "The current state of a Tailscale ProxyClass resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [metadata, name]
+                labelsFromPath:
+                  exported_namespace: [metadata, namespace]
+                  ready: [status, conditions, "[type=ProxyClassReady]", status]
+          - groupVersionKind:
+              group: tailscale.com
+              version: v1alpha1
+              kind: ProxyGroup
+            metricNamePrefix: gotk
+            metrics:
+              - name: "resource_info"
+                help: "The current state of a Tailscale ProxyGroup resource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name: [metadata, name]
+                labelsFromPath:
+                  exported_namespace: [metadata, namespace]
+                  ready: [status, conditions, "[type=ProxyGroupReady]", status]
           - groupVersionKind:
               group: helm.toolkit.fluxcd.io
               version: v2

--- a/renovate.json
+++ b/renovate.json
@@ -44,20 +44,16 @@
   ],
   "packageRules": [
     {
-      "description": "Automerge Docker image updates via GitHub native automerge (compatible with branch protection)",
+      "description": "Pause custom-regex auto-merge until PR Gate / required is enforced and R0 rules are proven",
       "matchManagers": ["custom.regex"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash",
+      "automerge": false,
       "commitMessagePrefix": "chore(deps): "
     },
     {
-      "description": "Automerge terraform minor/patch updates (providers and modules)",
+      "description": "Pause Terraform minor/patch auto-merge until PR Gate / required is enforced and R0 rules are proven",
       "matchManagers": ["terraform"],
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash",
+      "automerge": false,
       "commitMessagePrefix": "chore(deps): "
     },
     {

--- a/scripts/bootstrap_flux.sh
+++ b/scripts/bootstrap_flux.sh
@@ -1,3 +1,8 @@
+#!/usr/bin/env sh
+# Bootstrap is for a documented new-cluster recovery only; normal changes flow
+# through protected pull requests and Flux reconciliation.
+set -eu
+
 flux bootstrap github \
   --components-extra=image-reflector-controller,image-automation-controller \
   --token-auth=false \

--- a/scripts/ci/critical_change_guard.py
+++ b/scripts/ci/critical_change_guard.py
@@ -1,0 +1,749 @@
+#!/usr/bin/env python3
+"""Fail closed on destructive changes to reviewed GitOps resources.
+
+The GitHub workflow checks this script and its policy out from the PR base SHA.
+The proposed tree is treated only as YAML/Kustomize input: Kustomize exec plugins,
+networked functions, and Helm inflation are never enabled by this program.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class GuardError(RuntimeError):
+    """A malformed policy or manifest that must fail the PR."""
+
+
+@dataclass(frozen=True)
+class Identity:
+    api_version: str
+    kind: str
+    namespace: str
+    name: str
+
+    def display(self) -> str:
+        namespace = f"{self.namespace}/" if self.namespace else ""
+        return f"{self.api_version} {self.kind} {namespace}{self.name}"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, type=Path, help="Trusted base checkout")
+    parser.add_argument("--head", required=True, type=Path, help="Proposed PR checkout")
+    parser.add_argument("--policy", required=True, type=Path, help="Policy from trusted base")
+    parser.add_argument("--report", type=Path, help="Optional JSON report path")
+    return parser.parse_args()
+
+
+def read_yaml(path: Path) -> Any:
+    try:
+        with path.open(encoding="utf-8") as stream:
+            return yaml.safe_load(stream)
+    except (OSError, yaml.YAMLError) as error:
+        raise GuardError(f"Cannot parse YAML {path}: {error}") from error
+
+
+def documents(rendered: str, label: str) -> dict[Identity, dict[str, Any]]:
+    result: dict[Identity, dict[str, Any]] = {}
+    try:
+        values = yaml.safe_load_all(rendered)
+        for document in values:
+            if not isinstance(document, dict):
+                continue
+            api_version = document.get("apiVersion")
+            kind = document.get("kind")
+            metadata = document.get("metadata")
+            if not isinstance(api_version, str) or not isinstance(kind, str) or not isinstance(metadata, dict):
+                continue
+            name = metadata.get("name")
+            namespace = metadata.get("namespace", "")
+            if not isinstance(name, str) or not isinstance(namespace, str):
+                continue
+            identity = Identity(api_version, kind, namespace, name)
+            if identity in result:
+                raise GuardError(f"{label} renders duplicate identity {identity.display()}")
+            result[identity] = document
+    except yaml.YAMLError as error:
+        raise GuardError(f"Cannot parse rendered YAML for {label}: {error}") from error
+    return result
+
+
+def raw_documents(tree: Path, relative_path: str) -> dict[Identity, dict[str, Any]]:
+    """Load a policy-selected YAML file without evaluating Kustomize."""
+    path = tree / relative_path
+    if not path.is_file():
+        raise GuardError(f"Required raw policy target is missing: {path}")
+    try:
+        return documents(path.read_text(encoding="utf-8"), relative_path)
+    except OSError as error:
+        raise GuardError(f"Cannot read raw policy target {path}: {error}") from error
+
+
+def kustomization_file(directory: Path) -> Path | None:
+    """Return the local Kustomization file in a directory, when present."""
+    return next(
+        (directory / name for name in ("kustomization.yaml", "kustomization.yml", "Kustomization") if (directory / name).is_file()),
+        None,
+    )
+
+
+def is_remote_kustomize_reference(value: str) -> bool:
+    """Return whether a Kustomize resource/component value resolves remotely."""
+    return "://" in value or value.startswith(("git::", "github.com/", "git@", "ssh://"))
+
+
+def assert_no_direct_remote_kustomize_bases(target: Path) -> None:
+    """Reject remote declarations in one local Kustomization manifest."""
+    manifest_path = kustomization_file(target)
+    if manifest_path is None:
+        raise GuardError(f"Guard render target has no local Kustomization: {target}")
+    manifest = read_yaml(manifest_path)
+    if not isinstance(manifest, dict):
+        raise GuardError(f"Guard render target is not a YAML mapping: {manifest_path}")
+    for field in ("resources", "components", "crds"):
+        values = manifest.get(field, [])
+        if values is None:
+            continue
+        if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+            raise GuardError(f"Guard render target has invalid {field}: {manifest_path}")
+        for value in values:
+            if is_remote_kustomize_reference(value):
+                raise GuardError(f"Guard render target declares a remote {field} entry in {manifest_path}: {value}")
+
+
+def assert_no_remote_kustomize_bases(tree: Path, target: Path) -> None:
+    """Reject remote bases anywhere reachable from a guard render target.
+
+    Kustomize resolves nested local bases recursively. Checking only the root
+    Kustomization would allow a PR to add a remote base in a child directory, so
+    walk each local resource/component/CRD Kustomization before invoking the
+    renderer. Traversal is confined to the checkout to prevent path escapes.
+    """
+    root = tree.resolve()
+    pending = [target.resolve()]
+    visited: set[Path] = set()
+
+    while pending:
+        directory = pending.pop()
+        if directory in visited:
+            continue
+        visited.add(directory)
+        try:
+            directory.relative_to(root)
+        except ValueError as error:
+            raise GuardError(f"Guard render target escapes the checkout: {directory}") from error
+
+        manifest_path = kustomization_file(directory)
+        if manifest_path is None:
+            raise GuardError(f"Guard render target has no local Kustomization: {directory}")
+        manifest = read_yaml(manifest_path)
+        if not isinstance(manifest, dict):
+            raise GuardError(f"Guard render target is not a YAML mapping: {manifest_path}")
+
+        for field in ("resources", "components", "crds"):
+            values = manifest.get(field, [])
+            if values is None:
+                continue
+            if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+                raise GuardError(f"Guard render target has invalid {field}: {manifest_path}")
+            for value in values:
+                if is_remote_kustomize_reference(value):
+                    raise GuardError(
+                        f"Guard render target declares a remote {field} entry in {manifest_path}: {value}"
+                    )
+                child = (directory / value).resolve()
+                try:
+                    child.relative_to(root)
+                except ValueError as error:
+                    raise GuardError(
+                        f"Guard render target declares a {field} entry outside the checkout in {manifest_path}: {value}"
+                    ) from error
+                if child.is_dir() and kustomization_file(child) is not None:
+                    pending.append(child)
+
+
+def render(tree: Path, relative_target: str) -> dict[Identity, dict[str, Any]]:
+    target = tree / relative_target
+    if not target.is_dir():
+        raise GuardError(f"Required render target is missing: {target}")
+    assert_no_remote_kustomize_bases(tree, target)
+
+    environment = os.environ.copy()
+    # Kustomize plugins/functions are disabled unless explicitly enabled. Set the
+    # plugin home to a non-existent directory as an additional guardrail.
+    environment["KUSTOMIZE_PLUGIN_HOME"] = str(tree / ".disabled-kustomize-plugins")
+    completed = subprocess.run(
+        ["kustomize", "build", str(target)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise GuardError(f"kustomize build failed for {relative_target}: {detail}")
+    return documents(completed.stdout, relative_target)
+
+
+def identity_from_policy(entry: dict[str, Any]) -> Identity:
+    required = ("apiVersion", "kind", "name")
+    missing = [key for key in required if not isinstance(entry.get(key), str)]
+    if missing:
+        raise GuardError(f"Critical-resource policy entry is missing {', '.join(missing)}")
+    namespace = entry.get("namespace", "")
+    if not isinstance(namespace, str):
+        raise GuardError("Critical-resource policy namespace must be a string")
+    return Identity(entry["apiVersion"], entry["kind"], namespace, entry["name"])
+
+
+def value_at(document: dict[str, Any], dotted_path: str) -> Any:
+    """Resolve mapping fields while supporting Kubernetes keys containing dots."""
+    value: Any = document
+    parts = dotted_path.split(".")
+    for index, part in enumerate(parts):
+        if not isinstance(value, dict):
+            return None
+        if part in value:
+            value = value[part]
+            continue
+        # Annotation and label keys commonly contain dots and slashes. If the next
+        # component is not a mapping key, consume the remaining path as one key.
+        remaining = ".".join(parts[index:])
+        if remaining in value:
+            return value[remaining]
+        return None
+    return value
+
+
+def validate_root_composition(tree: Path, policy: dict[str, Any], side: str) -> list[str]:
+    root = policy.get("root_composition")
+    if not isinstance(root, dict):
+        raise GuardError("Policy root_composition must be an object")
+    relative_path = root.get("path")
+    expected_resources = root.get("resources")
+    if not isinstance(relative_path, str) or not isinstance(expected_resources, list) or not all(
+        isinstance(item, str) for item in expected_resources
+    ):
+        raise GuardError("Policy root_composition must contain path and string resources")
+
+    manifest_path = tree / relative_path
+    if not manifest_path.is_file():
+        return [f"{side}: required root composition file is missing: {relative_path}"]
+    manifest = read_yaml(manifest_path)
+    if not isinstance(manifest, dict) or manifest.get("apiVersion") != "kustomize.config.k8s.io/v1beta1" or manifest.get(
+        "kind"
+    ) != "Kustomization":
+        return [f"{side}: {relative_path} is not the expected local Kustomization"]
+    actual_resources = manifest.get("resources")
+    if actual_resources != expected_resources:
+        return [
+            f"{side}: {relative_path} must contain exactly {expected_resources}; found {actual_resources!r}"
+        ]
+    return []
+
+
+def intent_allows(
+    base: Path, head: Path, policy: dict[str, Any], resource_id: str, operation: str
+) -> tuple[bool, str]:
+    """Allow one R2 operation only after a consumed prior intent on main.
+
+    The first PR adds a resource-specific intent containing backup and rollback
+    evidence. The later destructive PR must remove that intent as well as make
+    the R2 change, preventing an old intent from authorizing a future operation.
+    """
+    intent_directory = policy.get("intent_directory")
+    if not isinstance(intent_directory, str):
+        raise GuardError("Policy intent_directory must be a string")
+    filename = resource_id.replace("/", "__") + ".yaml"
+    base_path = base / intent_directory / filename
+    head_path = head / intent_directory / filename
+    if not base_path.is_file():
+        return False, f"missing prior intent {intent_directory}/{filename}"
+    if head_path.exists():
+        return False, f"prior intent {intent_directory}/{filename} must be consumed in the R2 PR"
+    intent = read_yaml(base_path)
+    if not isinstance(intent, dict):
+        return False, f"invalid prior intent {base_path.relative_to(base)}"
+    if intent.get("resource") != resource_id:
+        return False, f"prior intent {base_path.relative_to(base)} names a different resource"
+    if intent.get("operation") != operation:
+        return (
+            False,
+            f"prior intent {base_path.relative_to(base)} has operation {intent.get('operation')!r}, expected {operation!r}",
+        )
+    for field in ("backup", "rollback"):
+        if not isinstance(intent.get(field), str) or not intent[field].strip():
+            return False, f"prior intent {base_path.relative_to(base)} has no {field} evidence"
+    return True, f"consumed prior intent {base_path.relative_to(base)} permits {operation}"
+
+
+def validate_intent_files(
+    base: Path, head: Path, policy: dict[str, Any], resource_ids: set[str]
+) -> tuple[list[str], set[str]]:
+    """Validate newly declared R2 intents and make existing intents immutable.
+
+    A preparation PR is useful only if its evidence is valid before it reaches
+    main. Once present on main, an intent may be consumed by its matching R2 PR,
+    but cannot be edited to authorize a different operation.
+    """
+    intent_directory = policy.get("intent_directory")
+    if not isinstance(intent_directory, str):
+        raise GuardError("Policy intent_directory must be a string")
+
+    base_directory = base / intent_directory
+    head_directory = head / intent_directory
+    base_files = {path.name: path for path in base_directory.glob("*.yaml")} if base_directory.is_dir() else {}
+    head_files = {path.name: path for path in head_directory.glob("*.yaml")} if head_directory.is_dir() else {}
+    errors: list[str] = []
+    removed_resources: set[str] = set()
+
+    def validate(path: Path, side: str) -> str | None:
+        document = read_yaml(path)
+        if not isinstance(document, dict):
+            errors.append(f"{side}: R2 intent {path.name} is not a YAML mapping")
+            return None
+        resource = document.get("resource")
+        operation = document.get("operation")
+        if not isinstance(resource, str) or resource not in resource_ids:
+            errors.append(f"{side}: R2 intent {path.name} names an unknown critical resource")
+            return None
+        expected_name = resource.replace("/", "__") + ".yaml"
+        if path.name != expected_name:
+            errors.append(f"{side}: R2 intent {path.name} must be named {expected_name}")
+        if operation not in {"remove", "change"}:
+            errors.append(f"{side}: R2 intent {path.name} must declare operation remove or change")
+        for field in ("backup", "rollback"):
+            if not isinstance(document.get(field), str) or not document[field].strip():
+                errors.append(f"{side}: R2 intent {path.name} has no {field} evidence")
+        return resource
+
+    for name, path in head_files.items():
+        resource = validate(path, "head")
+        if name in base_files and base_files[name].read_bytes() != path.read_bytes():
+            errors.append(f"head: existing R2 intent must not be modified: {intent_directory}/{name}")
+        if resource is not None and name not in base_files:
+            # Validation above records a new, machine-readable preparation intent.
+            continue
+
+    for name, path in base_files.items():
+        resource = validate(path, "base")
+        if name not in head_files and resource is not None:
+            removed_resources.add(resource)
+
+    return errors, removed_resources
+
+
+def matching_files(tree: Path, pattern: str) -> set[Path]:
+    """Return regular files selected by a small, policy-safe glob subset."""
+    if pattern.endswith("/**"):
+        root = tree / pattern[:-3]
+        if not root.exists():
+            return set()
+        return {path for path in root.rglob("*") if path.is_file()}
+    path = tree / pattern
+    return {path} if path.is_file() else set()
+
+
+def changed_tier0_paths(base: Path, head: Path, policy: dict[str, Any]) -> list[str]:
+    patterns = policy.get("tier0_paths", [])
+    if not isinstance(patterns, list) or not all(isinstance(pattern, str) for pattern in patterns):
+        raise GuardError("Policy tier0_paths must contain strings")
+
+    changed: set[str] = set()
+    for pattern in patterns:
+        base_files = matching_files(base, pattern)
+        head_files = matching_files(head, pattern)
+        relative_files = {
+            path.relative_to(base) for path in base_files
+        } | {
+            path.relative_to(head) for path in head_files
+        }
+        for relative_path in relative_files:
+            base_path = base / relative_path
+            head_path = head / relative_path
+            base_content = base_path.read_bytes() if base_path.is_file() else None
+            head_content = head_path.read_bytes() if head_path.is_file() else None
+            if base_content != head_content:
+                changed.add(relative_path.as_posix())
+    return sorted(changed)
+
+
+def names_from_depends_on(document: dict[str, Any], label: str) -> list[str]:
+    spec = document.get("spec")
+    if not isinstance(spec, dict):
+        raise GuardError(f"{label} has no spec mapping")
+    depends_on = spec.get("dependsOn", [])
+    if depends_on is None:
+        depends_on = []
+    if not isinstance(depends_on, list):
+        raise GuardError(f"{label} spec.dependsOn must be a list")
+    names: list[str] = []
+    for dependency in depends_on:
+        if not isinstance(dependency, dict) or not isinstance(dependency.get("name"), str):
+            raise GuardError(f"{label} has an invalid spec.dependsOn entry")
+        names.append(dependency["name"])
+    return names
+
+
+def validate_bootstrap_semantics(
+    resources: dict[Identity, dict[str, Any]], policy: dict[str, Any], side: str
+) -> list[str]:
+    """Validate the fixed Flux dependency boundary and substitution inputs."""
+    expected_dependencies = policy.get("bootstrap_dependencies")
+    if not isinstance(expected_dependencies, dict) or not all(
+        isinstance(name, str) and isinstance(dependencies, list) and all(isinstance(dep, str) for dep in dependencies)
+        for name, dependencies in expected_dependencies.items()
+    ):
+        raise GuardError("Policy bootstrap_dependencies must map names to string lists")
+
+    errors: list[str] = []
+    bootstrap: dict[str, dict[str, Any]] = {}
+    for identity, document in resources.items():
+        if (
+            identity.api_version == "kustomize.toolkit.fluxcd.io/v1"
+            and identity.kind == "Kustomization"
+            and identity.namespace == "flux-system"
+            and identity.name in expected_dependencies
+        ):
+            bootstrap[identity.name] = document
+
+    for name, expected in expected_dependencies.items():
+        document = bootstrap.get(name)
+        if document is None:
+            errors.append(f"{side}: required bootstrap Kustomization is absent: {name}")
+            continue
+        actual = names_from_depends_on(document, f"{side}: bootstrap/{name}")
+        if actual != expected:
+            errors.append(
+                f"{side}: bootstrap/{name} spec.dependsOn must be exactly {expected}; found {actual}"
+            )
+
+        spec = document.get("spec")
+        assert isinstance(spec, dict)  # validated by names_from_depends_on
+        source_ref = spec.get("sourceRef")
+        if not isinstance(source_ref, dict) or not isinstance(source_ref.get("kind"), str) or not isinstance(
+            source_ref.get("name"), str
+        ):
+            errors.append(f"{side}: bootstrap/{name} has an invalid spec.sourceRef")
+        path = spec.get("path")
+        if not isinstance(path, str) or not path.startswith("./"):
+            errors.append(f"{side}: bootstrap/{name} must declare a repository-relative spec.path")
+
+        post_build = spec.get("postBuild")
+        if not isinstance(post_build, dict):
+            errors.append(f"{side}: bootstrap/{name} has no spec.postBuild mapping")
+            continue
+        substitutions = post_build.get("substituteFrom")
+        if not isinstance(substitutions, list) or not substitutions:
+            errors.append(f"{side}: bootstrap/{name} has no spec.postBuild.substituteFrom entries")
+            continue
+        for source in substitutions:
+            if not isinstance(source, dict) or not isinstance(source.get("kind"), str) or not isinstance(
+                source.get("name"), str
+            ):
+                errors.append(f"{side}: bootstrap/{name} has an invalid substituteFrom entry")
+                continue
+            source_kind = source["kind"]
+            source_name = source["name"]
+            direct = Identity("v1", source_kind, "flux-system", source_name)
+            sealed = Identity("bitnami.com/v1alpha1", "SealedSecret", "flux-system", source_name)
+            if direct not in resources and not (source_kind == "Secret" and sealed in resources):
+                errors.append(
+                    f"{side}: bootstrap/{name} substituteFrom {source_kind}/{source_name} is not provided by root composition"
+                )
+    return errors
+
+
+def validate_bootstrap_paths(
+    tree: Path, resources: dict[Identity, dict[str, Any]], policy: dict[str, Any], side: str
+) -> list[str]:
+    """Ensure every Flux child path exists without evaluating its full tree.
+
+    The trusted guard renders its explicit local leaf targets. It intentionally
+    does not build aggregate child paths here: some catalog paths legitimately
+    contain remote bases, which would turn a trusted-base comparison into a
+    network fetch of PR-controlled configuration. The GitOps validator performs
+    the broader render separately on an ephemeral runner without credentials.
+    """
+    expected_dependencies = policy.get("bootstrap_dependencies")
+    assert isinstance(expected_dependencies, dict)
+    errors: list[str] = []
+    for name in expected_dependencies:
+        identity = Identity("kustomize.toolkit.fluxcd.io/v1", "Kustomization", "flux-system", name)
+        document = resources.get(identity)
+        if document is None:
+            continue
+        spec = document.get("spec")
+        if not isinstance(spec, dict) or not isinstance(spec.get("path"), str):
+            continue
+        relative_path = spec["path"].removeprefix("./")
+        target = tree / relative_path
+        if not target.is_dir():
+            errors.append(f"{side}: bootstrap/{name} spec.path is missing: {relative_path}")
+            continue
+        try:
+            # Bootstrap aggregates can contain non-critical legacy remote bases.
+            # The trusted guard renders declared local leaf targets separately and
+            # never follows a remote entry from a PR-controlled child path here.
+            assert_no_direct_remote_kustomize_bases(target)
+        except GuardError as error:
+            errors.append(f"{side}: bootstrap/{name} path validation failed: {error}")
+    return errors
+
+
+def safe_hardening_allows(
+    policy: dict[str, Any], event: dict[str, Any], base_document: dict[str, Any], head_document: dict[str, Any]
+) -> tuple[bool, str]:
+    """Allow only exact non-destructive Flux protection transitions."""
+    safe_hardening = policy.get("safe_hardening")
+    if not isinstance(safe_hardening, dict):
+        raise GuardError("Policy safe_hardening must be a mapping")
+
+    field = event.get("field")
+    if field == "spec.deletionPolicy":
+        desired = safe_hardening.get("deletion_policy")
+        if value_at(base_document, field) is None and value_at(head_document, field) == desired:
+            return True, f"safe hardening sets {field} to {desired!r}"
+        return False, f"{field} is not the allowed safe-hardening transition"
+
+    if field == "metadata.annotations":
+        desired = safe_hardening.get("prune_annotation")
+        if not isinstance(desired, str):
+            raise GuardError("Policy safe_hardening.prune_annotation must be a string")
+        base_annotations = value_at(base_document, field)
+        head_annotations = value_at(head_document, field)
+        if base_annotations is None:
+            base_annotations = {}
+        if not isinstance(base_annotations, dict) or not isinstance(head_annotations, dict):
+            return False, "prune hardening must preserve the annotations mapping"
+        prune_annotation = "kustomize.toolkit.fluxcd.io/prune"
+        expected_head = {**base_annotations, prune_annotation: desired}
+        if prune_annotation not in base_annotations and head_annotations == expected_head:
+            return True, f"safe hardening adds {prune_annotation}: {desired}"
+        return False, "metadata.annotations is not the allowed prune hardening transition"
+
+    return False, "not a safe-hardening field"
+
+
+def preparation_allows_deprotection(
+    base: Path, head: Path, policy: dict[str, Any], event: dict[str, Any], base_document: dict[str, Any], head_document: dict[str, Any]
+) -> tuple[bool, str]:
+    """Allow PR 1 to add an intent and remove only the Flux prune opt-out.
+
+    The second PR consumes that intent while removing the protected resource. This
+    is the only critical-field change permitted in the preparation PR.
+    """
+    if event.get("operation") != "change" or event.get("field") != "metadata.annotations":
+        return False, "not a prune deprotection event"
+    resource_id = event.get("resource")
+    if not isinstance(resource_id, str):
+        return False, "invalid critical resource id"
+
+    base_annotations = value_at(base_document, "metadata.annotations")
+    head_annotations = value_at(head_document, "metadata.annotations")
+    if not isinstance(base_annotations, dict) or head_annotations not in (None, {}) and not isinstance(head_annotations, dict):
+        return False, "prune deprotection must preserve the annotations mapping"
+    if head_annotations is None:
+        head_annotations = {}
+    prune_annotation = "kustomize.toolkit.fluxcd.io/prune"
+    if base_annotations.get(prune_annotation) != "disabled" or prune_annotation in head_annotations:
+        return False, "only removal of the prune: disabled annotation is permitted in a preparation PR"
+    expected_head = {key: value for key, value in base_annotations.items() if key != prune_annotation}
+    if head_annotations != expected_head:
+        return False, "preparation PR changed annotations other than the prune opt-out"
+
+    intent_directory = policy.get("intent_directory")
+    if not isinstance(intent_directory, str):
+        raise GuardError("Policy intent_directory must be a string")
+    filename = resource_id.replace("/", "__") + ".yaml"
+    base_path = base / intent_directory / filename
+    head_path = head / intent_directory / filename
+    if base_path.exists():
+        return False, f"preparation intent {intent_directory}/{filename} must be newly added"
+    if not head_path.is_file():
+        return False, f"missing preparation intent {intent_directory}/{filename}"
+    intent = read_yaml(head_path)
+    if not isinstance(intent, dict):
+        return False, f"invalid preparation intent {head_path.relative_to(head)}"
+    if intent.get("resource") != resource_id or intent.get("operation") != "remove":
+        return False, f"preparation intent {head_path.relative_to(head)} must declare {resource_id} remove"
+    for field in ("backup", "rollback"):
+        if not isinstance(intent.get(field), str) or not intent[field].strip():
+            return False, f"preparation intent {head_path.relative_to(head)} has no {field} evidence"
+    return True, f"new preparation intent {head_path.relative_to(head)} permits prune deprotection"
+
+
+def main() -> int:
+    args = parse_args()
+    base = args.base.resolve()
+    head = args.head.resolve()
+    policy_path = args.policy.resolve()
+    report: dict[str, Any] = {"r1": [], "r2": [], "errors": [], "permitted_r2": []}
+
+    try:
+        policy = read_yaml(policy_path)
+        if not isinstance(policy, dict) or policy.get("version") != 1:
+            raise GuardError("Critical-resource policy must be a version: 1 mapping")
+
+        for side, tree in (("base", base), ("head", head)):
+            report["errors"].extend(validate_root_composition(tree, policy, side))
+
+        for relative_path in policy.get("non_removable_files", []):
+            if not isinstance(relative_path, str):
+                raise GuardError("Policy non_removable_files must contain strings")
+            if not (head / relative_path).is_file():
+                report["errors"].append(f"head: protected file is missing or renamed: {relative_path}")
+
+        # A missing root composition file would make every later render fail with
+        # a generic Kustomize error. Surface the actual safety violation first.
+        if report["errors"]:
+            print("::error::Critical GitOps guard errors:")
+            for error in report["errors"]:
+                print(f"  - {error}")
+            if args.report:
+                args.report.parent.mkdir(parents=True, exist_ok=True)
+                args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            return 1
+
+        targets = policy.get("render_targets")
+        raw_targets = policy.get("raw_file_targets", {})
+        entries = policy.get("resources")
+        if not isinstance(targets, dict) or not isinstance(raw_targets, dict) or not isinstance(entries, list):
+            raise GuardError("Policy must contain render_targets, raw_file_targets, and resources")
+
+        resource_ids = {
+            entry.get("id") for entry in entries if isinstance(entry, dict) and isinstance(entry.get("id"), str)
+        }
+        intent_errors, consumed_intent_resources = validate_intent_files(base, head, policy, resource_ids)
+        report["errors"].extend(intent_errors)
+
+        rendered: dict[str, tuple[dict[Identity, dict[str, Any]], dict[Identity, dict[str, Any]]]] = {}
+        r2_records: list[tuple[dict[str, Any], dict[str, Any], dict[str, Any] | None]] = []
+        needed_targets = {entry.get("target") for entry in entries if isinstance(entry, dict)}
+        for target_name in needed_targets:
+            if not isinstance(target_name, str):
+                raise GuardError(f"Invalid target {target_name!r} in policy")
+            if isinstance(targets.get(target_name), str):
+                relative_target = targets[target_name]
+                rendered[target_name] = (render(base, relative_target), render(head, relative_target))
+            elif isinstance(raw_targets.get(target_name), str):
+                relative_target = raw_targets[target_name]
+                rendered[target_name] = (raw_documents(base, relative_target), raw_documents(head, relative_target))
+            else:
+                raise GuardError(f"Unknown render target {target_name!r} in policy")
+
+        bootstrap_base, bootstrap_head = rendered.get("bootstrap", ({}, {}))
+        report["errors"].extend(validate_bootstrap_semantics(bootstrap_base, policy, "base"))
+        report["errors"].extend(validate_bootstrap_semantics(bootstrap_head, policy, "head"))
+        report["errors"].extend(validate_bootstrap_paths(base, bootstrap_base, policy, "base"))
+        report["errors"].extend(validate_bootstrap_paths(head, bootstrap_head, policy, "head"))
+
+        for entry in entries:
+            if not isinstance(entry, dict) or not isinstance(entry.get("id"), str):
+                raise GuardError("Every policy resource needs a string id")
+            resource_id = entry["id"]
+            identity = identity_from_policy(entry)
+            target_name = entry.get("target")
+            base_resources, head_resources = rendered[target_name]
+            base_document = base_resources.get(identity)
+            head_document = head_resources.get(identity)
+            if base_document is None:
+                raise GuardError(f"Policy resource {resource_id} is absent from trusted base render: {identity.display()}")
+
+            if head_document is None:
+                event = {"resource": resource_id, "operation": "remove", "detail": identity.display()}
+                report["r2"].append(event)
+                r2_records.append((event, base_document, None))
+                continue
+
+            for level, field_name in (("r1", "r1_fields"), ("r2", "r2_fields")):
+                fields = entry.get(field_name, [])
+                if not isinstance(fields, list) or not all(isinstance(field, str) for field in fields):
+                    raise GuardError(f"Policy {resource_id} has invalid {field_name}")
+                for field in fields:
+                    if value_at(base_document, field) != value_at(head_document, field):
+                        event = {
+                            "resource": resource_id,
+                            "operation": "change",
+                            "field": field,
+                            "detail": identity.display(),
+                        }
+                        report[level].append(event)
+                        if level == "r2":
+                            r2_records.append((event, base_document, head_document))
+
+        tier0_changes = changed_tier0_paths(base, head, policy)
+        if tier0_changes:
+            report["tier0"] = tier0_changes
+            if report["r1"] or report["r2"] or report["errors"]:
+                report["errors"].append(
+                    "Tier 0 enforcement paths changed together with a critical-resource change: "
+                    + ", ".join(tier0_changes)
+                )
+
+        if consumed_intent_resources:
+            r2_resources = {event["resource"] for event in report["r2"]}
+            for resource_id in sorted(consumed_intent_resources - r2_resources):
+                report["errors"].append(
+                    f"head: R2 intent for {resource_id} was consumed without a matching R2 operation"
+                )
+
+        unapproved: list[dict[str, Any]] = []
+        for event, base_document, head_document in r2_records:
+            if event["operation"] == "remove":
+                allowed, detail = intent_allows(base, head, policy, event["resource"], event["operation"])
+            else:
+                if head_document is None:
+                    raise GuardError("R2 change event has no proposed resource document")
+                allowed, detail = safe_hardening_allows(policy, event, base_document, head_document)
+                if not allowed and event.get("field") == "metadata.annotations":
+                    allowed, detail = preparation_allows_deprotection(
+                        base, head, policy, event, base_document, head_document
+                    )
+                elif not allowed:
+                    allowed, detail = intent_allows(base, head, policy, event["resource"], event["operation"])
+            if allowed:
+                event["intent"] = detail
+                report["permitted_r2"].append(event)
+            else:
+                event["intent"] = detail
+                unapproved.append(event)
+
+        if report["r1"]:
+            print("::warning::Critical R1 changes detected; automatic semantic checks passed:")
+            for event in report["r1"]:
+                print(f"  - {event['resource']} {event['field']} ({event['detail']})")
+        if report["permitted_r2"]:
+            print("Critical R2 changes permitted by a prior branch-bound intent:")
+            for event in report["permitted_r2"]:
+                print(f"  - {event['resource']} {event['operation']}: {event['intent']}")
+        if report["errors"]:
+            print("::error::Critical GitOps guard errors:")
+            for error in report["errors"]:
+                print(f"  - {error}")
+        if unapproved:
+            print("::error::Unapproved destructive R2 changes:")
+            for event in unapproved:
+                print(f"  - {event['resource']} {event['operation']} ({event['detail']}): {event['intent']}")
+
+        if args.report:
+            args.report.parent.mkdir(parents=True, exist_ok=True)
+            args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return 1 if report["errors"] or unapproved else 0
+    except GuardError as error:
+        print(f"::error::{error}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rotate-oidc-sealed-secrets.sh
+++ b/scripts/rotate-oidc-sealed-secrets.sh
@@ -34,7 +34,7 @@ case "${1:-}" in
     ;;
 esac
 
-repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 cd "$repo_root"
 
 for command in kubectl kubeseal mktemp openssl; do

--- a/tests/ci/test_critical_change_guard.py
+++ b/tests/ci/test_critical_change_guard.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Regression tests for the trusted-base critical GitOps guard."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GUARD = ROOT / "scripts/ci/critical_change_guard.py"
+POLICY = ROOT / ".github/critical-resources.yaml"
+
+
+class CriticalChangeGuardTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.base = Path(self.tempdir.name) / "base"
+        self.head = Path(self.tempdir.name) / "head"
+        # Terraform validation may create provider state below Coder templates.
+        # Test fixtures copy only repository inputs, never generated runtime state.
+        ignore = shutil.ignore_patterns(".git", "__pycache__", ".pytest_cache", ".coder", ".terraform")
+        shutil.copytree(ROOT, self.base, ignore=ignore)
+        shutil.copytree(ROOT, self.head, ignore=ignore)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def run_guard(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(GUARD),
+                "--base",
+                str(self.base),
+                "--head",
+                str(self.head),
+                "--policy",
+                str(self.base / POLICY.relative_to(ROOT)),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_identical_trees_pass(self) -> None:
+        completed = self.run_guard()
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+
+    def test_missing_root_composition_fails(self) -> None:
+        (self.head / "clusters/kyrion/kustomization.yaml").unlink()
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("protected file is missing or renamed", completed.stdout)
+
+    def test_semantic_connector_removal_fails_without_intent(self) -> None:
+        kustomization = self.head / "infrastructure/configs/tailscale/kustomization.yaml"
+        kustomization.write_text(
+            kustomization.read_text(encoding="utf-8").replace("  - connector.yaml\n", ""),
+            encoding="utf-8",
+        )
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("tailscale/connector remove", completed.stdout)
+        self.assertIn("missing prior intent", completed.stdout)
+
+    def test_consumed_intent_allows_connector_removal(self) -> None:
+        intent_dir = self.base / ".github/critical-removal-intents"
+        intent_dir.mkdir(parents=True, exist_ok=True)
+        intent = {
+            "resource": "tailscale/connector",
+            "operation": "remove",
+            "backup": "Not applicable: Connector has no persistent data.",
+            "rollback": "Restore connector.yaml from the preceding known-good commit.",
+        }
+        intent_path = intent_dir / "tailscale__connector.yaml"
+        intent_path.write_text(yaml.safe_dump(intent, sort_keys=False), encoding="utf-8")
+        shutil.copy2(intent_path, self.head / intent_path.relative_to(self.base))
+
+        kustomization = self.head / "infrastructure/configs/tailscale/kustomization.yaml"
+        kustomization.write_text(
+            kustomization.read_text(encoding="utf-8").replace("  - connector.yaml\n", ""),
+            encoding="utf-8",
+        )
+        (self.head / ".github/critical-removal-intents/tailscale__connector.yaml").unlink()
+
+        completed = self.run_guard()
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertIn("permitted by a prior", completed.stdout)
+
+    def test_bootstrap_dependency_change_fails_without_intent(self) -> None:
+        manifest = self.head / "clusters/kyrion/apps.yaml"
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8").replace("  dependsOn:\n    - name: infra-configs\n", ""),
+            encoding="utf-8",
+        )
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("bootstrap/apps spec.dependsOn", completed.stdout)
+        self.assertIn("missing prior intent", completed.stdout)
+
+    def test_prune_deprotection_requires_new_intent(self) -> None:
+        manifest = self.head / "clusters/kyrion/apps.yaml"
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8").replace(
+                "    kustomize.toolkit.fluxcd.io/prune: disabled\n", ""
+            ),
+            encoding="utf-8",
+        )
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("missing preparation intent", completed.stdout)
+
+    def test_prune_deprotection_with_new_intent_passes(self) -> None:
+        manifest = self.head / "clusters/kyrion/apps.yaml"
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8").replace(
+                "    kustomize.toolkit.fluxcd.io/prune: disabled\n", ""
+            ),
+            encoding="utf-8",
+        )
+        intent = {
+            "resource": "bootstrap/apps",
+            "operation": "remove",
+            "backup": "Not applicable: this Kustomization has no persistent payload.",
+            "rollback": "Restore apps.yaml from the known-good commit.",
+        }
+        intent_path = self.head / ".github/critical-removal-intents/bootstrap__apps.yaml"
+        intent_path.write_text(yaml.safe_dump(intent, sort_keys=False), encoding="utf-8")
+        completed = self.run_guard()
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertIn("preparation intent", completed.stdout)
+
+    def test_new_intent_requires_complete_machine_readable_evidence(self) -> None:
+        intent = {
+            "resource": "tailscale/connector",
+            "operation": "remove",
+            "backup": "",
+            "rollback": "Restore connector.yaml from the known-good commit.",
+        }
+        intent_path = self.head / ".github/critical-removal-intents/tailscale__connector.yaml"
+        intent_path.write_text(yaml.safe_dump(intent, sort_keys=False), encoding="utf-8")
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("has no backup evidence", completed.stdout)
+
+    def test_consumed_intent_requires_matching_r2_operation(self) -> None:
+        intent_dir = self.base / ".github/critical-removal-intents"
+        intent_dir.mkdir(parents=True, exist_ok=True)
+        intent = {
+            "resource": "tailscale/connector",
+            "operation": "change",
+            "backup": "Not applicable: Connector has no persistent data.",
+            "rollback": "Restore connector.yaml from the preceding known-good commit.",
+        }
+        intent_path = intent_dir / "tailscale__connector.yaml"
+        intent_path.write_text(yaml.safe_dump(intent, sort_keys=False), encoding="utf-8")
+        shutil.copy2(intent_path, self.head / intent_path.relative_to(self.base))
+        (self.head / ".github/critical-removal-intents/tailscale__connector.yaml").unlink()
+
+        kustomization = self.head / "infrastructure/configs/tailscale/kustomization.yaml"
+        kustomization.write_text(
+            kustomization.read_text(encoding="utf-8").replace("  - connector.yaml\n", ""),
+            encoding="utf-8",
+        )
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("expected 'remove'", completed.stdout)
+
+    def test_consumed_intent_requires_a_matching_r2_change(self) -> None:
+        intent_dir = self.base / ".github/critical-removal-intents"
+        intent_dir.mkdir(parents=True, exist_ok=True)
+        intent = {
+            "resource": "tailscale/connector",
+            "operation": "remove",
+            "backup": "Not applicable: Connector has no persistent data.",
+            "rollback": "Restore connector.yaml from the preceding known-good commit.",
+        }
+        intent_path = intent_dir / "tailscale__connector.yaml"
+        intent_path.write_text(yaml.safe_dump(intent, sort_keys=False), encoding="utf-8")
+        shutil.copy2(intent_path, self.head / intent_path.relative_to(self.base))
+        (self.head / ".github/critical-removal-intents/tailscale__connector.yaml").unlink()
+
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("consumed without a matching R2 operation", completed.stdout)
+
+    def test_new_change_intent_with_evidence_is_allowed(self) -> None:
+        intent = {
+            "resource": "system-upgrade/plan-crd",
+            "operation": "change",
+            "backup": "Plan inventory and CRD backup reference before migration.",
+            "rollback": "Restore the prior pinned CRD artifact from the known-good commit.",
+        }
+        intent_path = self.head / ".github/critical-removal-intents/system-upgrade__plan-crd.yaml"
+        intent_path.write_text(yaml.safe_dump(intent, sort_keys=False), encoding="utf-8")
+        completed = self.run_guard()
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+
+    def test_existing_intent_cannot_be_modified(self) -> None:
+        intent_dir = self.base / ".github/critical-removal-intents"
+        intent_dir.mkdir(parents=True, exist_ok=True)
+        intent_path = intent_dir / "tailscale__connector.yaml"
+        intent_path.write_text(
+            yaml.safe_dump(
+                {
+                    "resource": "tailscale/connector",
+                    "operation": "remove",
+                    "backup": "Not applicable: Connector has no persistent data.",
+                    "rollback": "Restore connector.yaml from the known-good commit.",
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        head_intent = self.head / intent_path.relative_to(self.base)
+        shutil.copy2(intent_path, head_intent)
+        head_intent.write_text(
+            head_intent.read_text(encoding="utf-8").replace(
+                "Restore connector.yaml", "Replace the recovery procedure"
+            ),
+            encoding="utf-8",
+        )
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("existing R2 intent must not be modified", completed.stdout)
+
+    def test_nested_remote_base_fails_before_rendering(self) -> None:
+        nested = self.head / "apps/base/apprise-api/kustomization.yaml"
+        nested.write_text(
+            nested.read_text(encoding="utf-8").replace(
+                "  - apprise-api.yaml\n",
+                "  - apprise-api.yaml\n  - https://example.invalid/untrusted.yaml\n",
+            ),
+            encoding="utf-8",
+        )
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("remote resources entry", completed.stdout)
+
+    def test_system_upgrade_crd_removal_fails_without_intent(self) -> None:
+        kustomization = self.head / "infrastructure/controllers/system-upgrade/kustomization.yaml"
+        kustomization.write_text(
+            kustomization.read_text(encoding="utf-8").replace("  - crd.yaml\n", ""),
+            encoding="utf-8",
+        )
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("system-upgrade/plan-crd remove", completed.stdout)
+        self.assertIn("missing prior intent", completed.stdout)
+
+    def test_system_upgrade_crd_schema_change_fails_without_intent(self) -> None:
+        manifest = self.head / "infrastructure/controllers/system-upgrade/crd.yaml"
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8").replace("  group: upgrade.cattle.io\n", "  group: unsafe.example\n", 1),
+            encoding="utf-8",
+        )
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("system-upgrade/plan-crd change", completed.stdout)
+        self.assertIn("missing prior intent", completed.stdout)
+
+    def test_consumed_intent_allows_system_upgrade_crd_schema_change(self) -> None:
+        intent_dir = self.base / ".github/critical-removal-intents"
+        intent_dir.mkdir(parents=True, exist_ok=True)
+        intent = {
+            "resource": "system-upgrade/plan-crd",
+            "operation": "change",
+            "backup": "Plan inventory and CRD backup reference before migration.",
+            "rollback": "Restore the prior pinned CRD artifact from the known-good commit.",
+        }
+        intent_path = intent_dir / "system-upgrade__plan-crd.yaml"
+        intent_path.write_text(yaml.safe_dump(intent, sort_keys=False), encoding="utf-8")
+        shutil.copy2(intent_path, self.head / intent_path.relative_to(self.base))
+
+        manifest = self.head / "infrastructure/controllers/system-upgrade/crd.yaml"
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8").replace("  group: upgrade.cattle.io\n", "  group: upgraded.example\n", 1),
+            encoding="utf-8",
+        )
+        (self.head / ".github/critical-removal-intents/system-upgrade__plan-crd.yaml").unlink()
+
+        completed = self.run_guard()
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertIn("permitted by a prior", completed.stdout)
+
+    def test_tier0_change_cannot_accompany_critical_change(self) -> None:
+        policy = self.head / ".github/critical-resources.yaml"
+        policy.write_text(policy.read_text(encoding="utf-8") + "\n# attempted weakening\n", encoding="utf-8")
+        manifest = self.head / "clusters/kyrion/apps.yaml"
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8").replace("    - name: infra-configs\n", ""),
+            encoding="utf-8",
+        )
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("Tier 0 enforcement paths changed", completed.stdout)
+
+    def test_safe_hardening_can_add_orphan_without_intent(self) -> None:
+        manifest = self.base / "clusters/kyrion/apps.yaml"
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8").replace(
+                "  # Orphan managed resources if this Kustomization object is deleted; normal\n"
+                "  # source reconciliation still uses prune: true.\n"
+                "  deletionPolicy: Orphan\n",
+                "",
+            ),
+            encoding="utf-8",
+        )
+        completed = self.run_guard()
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertIn("safe hardening", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change and risk

- [x] I identified the affected domain(s): GitOps, charts, Coder, Actions/scripts, functions, and docs.
- [x] I ran the applicable local validation commands and recorded them below.
- [ ] I enabled native auto-merge with `gh pr merge --auto --squash` (pending successful required checks).

This is the bootstrap PR for the PR-only safety controls and the trusted-base critical-change guard. It includes R1/R2-sensitive GitOps safeguards, but no resource deletion or storage migration. The system-upgrade Plan CRD is vendored from the reviewed `v0.20.1` asset and pinned to the matching controller tag; the existing cluster had already reconciled that release.

Refs #87, #88, #89, #90, #91, #92, #57, #58, #59, #60, #65, #66, #67.

## Critical / destructive changes

- [ ] Not applicable.
- [x] This is R1: it changes Flux bootstrap/recovery protections, Tailscale critical-resource annotations, CI workflows, and the system-upgrade source boundary.
- [ ] This is R2: I followed `docs/runbooks/destructive-gitops-change.md`, including the required two-PR intent/consumption sequence and backup/rollback evidence.

No R2 removal, PVC identity/storage mutation, or intentional pruning expansion is included.

## Validation evidence

- `python3 -m unittest tests.ci.test_critical_change_guard` — 18 tests passed.
- `python3 scripts/ci/critical_change_guard.py --base . --head . --policy .github/critical-resources.yaml` — clean report.
- `kustomize build` for the cluster root, system-upgrade, controller/config catalogs, apps, and monitoring — passed.
- `flux build kustomization` for apps, infra-controllers, infra-configs, monitoring-controllers, and monitoring-configs — passed.
- `ct lint --config ct.yaml --all` — passed; `helm unittest` passed (18 cron-job / 100 onechart tests).
- `actionlint` 1.7.9 (checksum verified), `shellcheck scripts/*.sh`, `renovate-config-validator`, `yamllint .`, changed-YAML parsing, Terraform `fmt -check`, and `git diff --check` — passed. Yamllint retains only line-length warnings for encrypted values and existing long lines.
- Terraform `init`/`validate` could not complete locally because fetching `coder/coder` provider v2.18.0 timed out from GitHub; no generated Terraform state remains in this branch.

## Rollback

Revert this PR through a normal PR and native squash auto-merge after validating the same GitOps targets. Do not use a direct push or manual cluster mutation. Server-side ruleset configuration, an off-cluster backup/restore drill, and verified out-of-band access remain follow-up operator work described in issue #90 and the new runbooks.
