### PR TITLE
test(ci): verify PR Gate doc-only path

### DIFF
--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -22,9 +22,11 @@ procedure.
 ## `PR Gate` fan-in behavior
 
 The target ruleset configuration is intentionally enabled only after this workflow
-has reached the default branch and passed a test PR. Until that server-side step is
-complete, the workflow is diagnostic and repository policy still requires agents to
-use PRs and native auto-merge voluntarily.
+has reached the default branch and passed a test PR. Before configuring the
+server-side required context, maintainers must use a documentation-only PR to
+verify baseline and critical success plus intentional skips by the conditional
+validators. Until that server-side step is complete, the workflow is diagnostic and
+repository policy still requires agents to use PRs and native auto-merge voluntarily.
 
 `pr-gate.yml` is loaded from the trusted default branch with
 `pull_request_target`. It checks out the proposed head SHA only as data, uses


### PR DESCRIPTION
## PR Gate rollout test

This documentation-only PR verifies the PR Gate baseline and critical success path plus the intentional skip behavior of conditional validators before `PR Gate / required` is configured as a server-side required context.

This PR contains no R1/R2 operation.