### PR TITLE
fix(ci): preserve trusted PR Gate config

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -117,6 +117,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           ref: ${{ needs.detect.outputs.head_sha }}
+          clean: false
           persist-credentials: false
 
       - name: Install YAML parser and linter
@@ -360,6 +361,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           ref: ${{ needs.detect.outputs.head_sha }}
+          clean: false
           persist-credentials: false
 
       - name: Fetch and identify changed templates
@@ -430,6 +432,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           ref: ${{ needs.detect.outputs.head_sha }}
+          clean: false
           persist-credentials: false
 
       - name: Install checksum-verified actionlint


### PR DESCRIPTION
## Summary
- Preserve the trusted `base/` checkout when PR Gate subsequently checks out proposed content.
- Retain trusted yamllint and actionlint configuration for the baseline and Actions/scripts jobs.
- Apply the same preservation in Coder so trusted-base and head content coexist consistently.

This bootstrapping repair addresses the trusted checkout lifetime defect exposed by rollout PR #95. It has no R2 operation. Legacy required checks remain the only enforcement until this repair has successfully rolled out; PR Gate may still fail on this PR because GitHub executes the trusted workflow from current `main`, which is the known buggy copy.

## Validation
- Checksum-verified `actionlint` on `.github/workflows/*`
- `git diff --check`