### PR TITLE
fix(ci): order trusted PR Gate checkouts

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -106,18 +106,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect
     steps:
+      - name: Check out proposed content as data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.head_sha }}
+          persist-credentials: false
+
       - name: Check out trusted base configuration
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           ref: ${{ needs.detect.outputs.base_sha }}
           path: base
-          persist-credentials: false
-
-      - name: Check out proposed content as data
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
-        with:
-          ref: ${{ needs.detect.outputs.head_sha }}
-          clean: false
           persist-credentials: false
 
       - name: Install YAML parser and linter
@@ -350,18 +349,17 @@ jobs:
     needs: detect
     if: needs.detect.outputs.coder == 'true'
     steps:
+      - name: Check out proposed templates as data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.head_sha }}
+          persist-credentials: false
+
       - name: Check out trusted base for changed-template detection
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           ref: ${{ needs.detect.outputs.base_sha }}
           path: base
-          persist-credentials: false
-
-      - name: Check out proposed templates as data
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
-        with:
-          ref: ${{ needs.detect.outputs.head_sha }}
-          clean: false
           persist-credentials: false
 
       - name: Fetch and identify changed templates
@@ -421,18 +419,17 @@ jobs:
     needs: detect
     if: needs.detect.outputs.actions == 'true'
     steps:
+      - name: Check out proposed workflows and scripts as data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.head_sha }}
+          persist-credentials: false
+
       - name: Check out trusted actionlint configuration
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
           ref: ${{ needs.detect.outputs.base_sha }}
           path: base
-          persist-credentials: false
-
-      - name: Check out proposed workflows and scripts as data
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
-        with:
-          ref: ${{ needs.detect.outputs.head_sha }}
-          clean: false
           persist-credentials: false
 
       - name: Install checksum-verified actionlint


### PR DESCRIPTION
## Summary
- check out each proposed head SHA at the workspace root before checking out the trusted base SHA under `base`
- remove now-redundant `clean: false` from the baseline, Coder, and Actions jobs
- preserve explicit SHA refs, read-only permissions, credentialless checkouts, and the data-only validation model

This repairs the persistent `base/.yamllint.yaml` checkout failure observed by PR #95. It contains no R2 operation.

## Validation
- structural checkout-order assertion for `baseline`, `coder`, and `actions`
- checksum-verified actionlint 1.7.9
- `git diff --check`

## Expected CI bootstrap behavior
The existing default-branch `pull_request_target` workflow is still the prior broken trusted workflow, so the new `PR Gate / baseline` and aggregate `PR Gate / required` may fail on this PR until this repair merges. The legacy required `yamllint` and `gitleaks` checks remain the enforcement criteria for this bootstrap repair.