### PR TITLE
fix(ci): repair PR Gate gitleaks scan

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -22,6 +22,8 @@ env:
   KUBECONFORM_SHA256: 9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883
   ACTIONLINT_VERSION: 1.7.9
   ACTIONLINT_SHA256: 233b280d05e100837f4af1433c7b40a5dcb306e3aa68fb4f17f8a7f45a7df7b4
+  GITLEAKS_VERSION: 8.30.1
+  GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
 
 jobs:
   detect:
@@ -317,12 +319,49 @@ jobs:
               )
           PY
 
-      - name: Scan the proposed revision for leaked secrets
-        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+      - name: Scan the trusted base-to-head diff for leaked secrets
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-          GITLEAKS_ENABLE_COMMENTS: "false"
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
+          BASE_SHA: ${{ needs.detect.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.detect.outputs.head_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          scanner_dir="$RUNNER_TEMP/gitleaks"
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          mkdir -p "$scanner_dir"
+          curl -fsSL -o "$scanner_dir/$archive" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
+          echo "${GITLEAKS_SHA256}  ${scanner_dir}/${archive}" | sha256sum --check --strict
+          tar -xzf "$scanner_dir/$archive" -C "$scanner_dir"
+
+          # Fetch the proposed revision as Git data and verify it against the
+          # PR payload. The scanner runs only the checksum-verified binary;
+          # it never executes code, workflow files, or configuration from HEAD.
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-head"
+          test "$(git rev-parse "$BASE_SHA")" = "$BASE_SHA"
+          test "$(git rev-parse refs/remotes/origin/pr-head)" = "$HEAD_SHA"
+
+          # Extract only added lines from the trusted SHA-to-SHA diff. The
+          # --no-git file scan has no access to the checkout; executing from
+          # scanner_dir and unsetting config variables force Gitleaks' built-in
+          # rules rather than a PR-controlled .gitleaks.toml/.gitleaksignore.
+          git diff --no-ext-diff --unified=0 "$BASE_SHA" "$HEAD_SHA" -- \
+            | awk '
+                /^@@ / { in_hunk = 1; next }
+                in_hunk && /^\+/ { sub(/^\+/, ""); print }
+              ' > "$scanner_dir/proposed.diff"
+          (
+            cd "$scanner_dir"
+            env -u GITLEAKS_CONFIG -u GITLEAKS_CONFIG_TOML ./gitleaks detect \
+              --no-git \
+              --source "$scanner_dir/proposed.diff" \
+              --gitleaks-ignore-path "$scanner_dir" \
+              --no-banner \
+              --no-color \
+              --redact \
+              --exit-code 1
+          )
 
   critical:
     name: critical GitOps guard


### PR DESCRIPTION
## Summary
- Bootstrap repair for #95: replaces the unsupported `gitleaks/gitleaks-action` invocation under `pull_request_target` with a checksum-verified Gitleaks CLI scan of added base-to-head diff data.
- R2: no.
- Settings changes: none.

## Validation
- `git diff --check`
- checksum-verified actionlint against `.github/workflows/pr-gate.yml`
- checksum-verified Gitleaks v8.30.1 isolated `--no-git` diff scan, including a positive control that failed with exit code 1

The inherited PR Gate run is expected to show the pre-repair `gitleaks/gitleaks-action` baseline failure because `pull_request_target` loads its workflow definition from the current default branch. Legacy yamllint and gitleaks checks remain the merge evidence for this bootstrap repair.