### PR TITLE
refactor(ci): extract PR Gate helpers

### DIFF
--- a/.github/critical-resources.yaml
+++ b/.github/critical-resources.yaml
@@ -25,7 +25,7 @@ tier0_paths:
   - .github/actionlint.yaml
   - .github/critical-resources.yaml
   - .github/workflows/**
-  - scripts/ci/critical_change_guard.py
+  - scripts/ci/**
 # The root render contains these Flux Kustomizations. Dependencies must retain
 # this controller -> configuration -> workload ordering and remain acyclic.
 bootstrap_dependencies:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -53,55 +53,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-head"
-          fetched_head="$(git rev-parse refs/remotes/origin/pr-head)"
-          test "$fetched_head" = "$HEAD_SHA"
-
-          gitops=false
-          helm=false
-          coder=false
-          actions=false
-          functions=false
-
-          while IFS= read -r path; do
-            case "$path" in
-              clusters/*|infrastructure/*|apps/*|monitoring/*)
-                gitops=true
-                ;;
-              charts/*|ct.yaml)
-                helm=true
-                ;;
-              coder/templates/*)
-                coder=true
-                ;;
-              functions/*)
-                functions=true
-                ;;
-              .github/workflows/*|.github/actions/*|scripts/*)
-                actions=true
-                ;;
-            esac
-
-            case "$path" in
-              .github/workflows/**|.github/actionlint.yaml|.github/critical-resources.yaml|.github/CODEOWNERS|scripts/ci/critical_change_guard.py)
-                gitops=true
-                helm=true
-                coder=true
-                actions=true
-                functions=true
-                ;;
-            esac
-          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
-
-          {
-            echo "base_sha=$BASE_SHA"
-            echo "head_sha=$HEAD_SHA"
-            echo "gitops=$gitops"
-            echo "helm=$helm"
-            echo "coder=$coder"
-            echo "actions=$actions"
-            echo "functions=$functions"
-          } >> "$GITHUB_OUTPUT"
+          python3 scripts/ci/detect_pr_gate_domains.py \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --pr-number "$PR_NUMBER" \
+            --github-output "$GITHUB_OUTPUT"
 
   baseline:
     name: baseline
@@ -135,15 +92,10 @@ jobs:
       - name: Parse CI policy and function YAML
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          from pathlib import Path
-          import yaml
-
-          for directory in (Path('.github'), Path('functions')):
-              for path in sorted(directory.rglob('*.yaml')):
-                  with path.open(encoding='utf-8') as stream:
-                      list(yaml.safe_load_all(stream))
-          PY
+          python3 base/scripts/ci/parse_yaml_paths.py \
+            --root "$GITHUB_WORKSPACE" \
+            --directory .github \
+            --directory functions
 
       - name: Reject changed plaintext Secret manifests from the trusted diff
         env:
@@ -152,216 +104,18 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "$BASE_SHA"
-          git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-head"
-          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
-          test "$(git rev-parse "$BASE_SHA")" = "$BASE_SHA"
-          test "$(git rev-parse refs/remotes/origin/pr-head)" = "$HEAD_SHA"
-          python3 - <<'PY'
-          import os
-          import subprocess
-          import sys
-          from pathlib import PurePosixPath
-
-          import yaml
-
-          BASE_SHA = os.environ["BASE_SHA"]
-          HEAD_SHA = os.environ["HEAD_SHA"]
-          ROOTS = ("apps", "clusters", "infrastructure", "monitoring", "functions")
-          EXCEPTION_PATH = "infrastructure/configs/ci/copilot-agent-rbac/secret.yaml"
-
-
-          class UniqueKeyLoader(yaml.SafeLoader):
-              pass
-
-
-          def construct_mapping(loader, node, deep=False):
-              mapping = {}
-              for key_node, value_node in node.value:
-                  key = loader.construct_object(key_node, deep=deep)
-                  if key in mapping:
-                      raise yaml.YAMLError(f"duplicate mapping key: {key!r}")
-                  mapping[key] = loader.construct_object(value_node, deep=deep)
-              return mapping
-
-
-          UniqueKeyLoader.add_constructor(
-              yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping
-          )
-
-
-          def fail(message):
-              print(f"::error::{message}", file=sys.stderr)
-              raise SystemExit(1)
-
-
-          def git(*args):
-              try:
-                  return subprocess.run(
-                      ["git", *args],
-                      check=True,
-                      stdout=subprocess.PIPE,
-                      stderr=subprocess.PIPE,
-                  ).stdout
-              except subprocess.CalledProcessError as error:
-                  detail = error.stderr.decode("utf-8", errors="replace").strip()
-                  fail(f"Unable to calculate the trusted base/head diff: {detail}")
-
-
-          def exception_is_exact(document):
-              return (
-                  isinstance(document, dict)
-                  and set(document) == {"apiVersion", "kind", "metadata", "type"}
-                  and document["apiVersion"] == "v1"
-                  and document["kind"] == "Secret"
-                  and document["type"] == "kubernetes.io/service-account-token"
-                  and document["metadata"]
-                  == {
-                      "name": "copilot-agent-readonly-token",
-                      "namespace": "arc-runners",
-                      "annotations": {
-                          "kubernetes.io/service-account.name": "copilot-agent-readonly"
-                      },
-                  }
-              )
-
-
-          def find_secret_mappings(value, seen=None):
-              if seen is None:
-                  seen = set()
-              if isinstance(value, (dict, list)):
-                  if id(value) in seen:
-                      return []
-                  seen.add(id(value))
-              if isinstance(value, dict):
-                  matches = [value] if value.get("kind") == "Secret" else []
-                  for child in value.values():
-                      matches.extend(find_secret_mappings(child, seen))
-                  return matches
-              if isinstance(value, list):
-                  matches = []
-                  for child in value:
-                      matches.extend(find_secret_mappings(child, seen))
-                  return matches
-              return []
-
-
-          raw_diff = git(
-              "diff",
-              "--name-status",
-              "-z",
-              "--find-renames",
-              "--find-copies",
-              "--diff-filter=ACMR",
-              BASE_SHA,
-              HEAD_SHA,
-              "--",
-              *ROOTS,
-          )
-          fields = raw_diff.split(b"\0")
-          if fields and fields[-1] == b"":
-              fields.pop()
-
-          changed_paths = []
-          index = 0
-          while index < len(fields):
-              try:
-                  status = fields[index].decode("ascii")
-              except UnicodeDecodeError:
-                  fail("Trusted diff returned a non-ASCII status")
-              index += 1
-              if not status or status[0] not in "ACMR":
-                  fail(f"Trusted diff returned an unexpected status: {status!r}")
-              if status[0] in "RC":
-                  if index + 1 >= len(fields):
-                      fail("Trusted diff ended while reading a rename or copy")
-                  index += 1  # Old path; only the proposed destination is checked.
-              if index >= len(fields):
-                  fail("Trusted diff ended while reading a changed path")
-              try:
-                  path = fields[index].decode("utf-8")
-              except UnicodeDecodeError:
-                  fail("Trusted diff contains a non-UTF-8 path")
-              index += 1
-              candidate = PurePosixPath(path)
-              if candidate.is_absolute() or ".." in candidate.parts:
-                  fail(f"Trusted diff returned an unsafe path: {path}")
-              if not any(path == root or path.startswith(f"{root}/") for root in ROOTS):
-                  fail(f"Trusted diff returned a path outside the GitOps roots: {path}")
-              if path.lower().endswith((".yaml", ".yml")):
-                  changed_paths.append(path)
-
-          for path in changed_paths:
-              try:
-                  content = git("show", f"{HEAD_SHA}:{path}")
-                  documents = list(yaml.load_all(content, Loader=UniqueKeyLoader))
-              except (yaml.YAMLError, UnicodeDecodeError) as error:
-                  fail(f"Could not parse changed YAML document {path}: {error}")
-
-              secret_documents = [
-                  secret
-                  for document in documents
-                  for secret in find_secret_mappings(document)
-              ]
-              if not secret_documents:
-                  continue
-              if (
-                  path == EXCEPTION_PATH
-                  and len(documents) == 1
-                  and len(secret_documents) == 1
-                  and secret_documents[0] is documents[0]
-                  and exception_is_exact(documents[0])
-              ):
-                  continue
-              fail(
-                  f"Bare kind: Secret manifest in {path} is forbidden; use SealedSecret "
-                  "or a consumer-native Secret reference."
-              )
-          PY
+          python3 base/scripts/ci/check_changed_secrets.py \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --pr-number "$PR_NUMBER"
 
       - name: Scan the trusted base-to-head diff for leaked secrets
         env:
           BASE_SHA: ${{ needs.detect.outputs.base_sha }}
           HEAD_SHA: ${{ needs.detect.outputs.head_sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          scanner_dir="$RUNNER_TEMP/gitleaks"
-          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          mkdir -p "$scanner_dir"
-          curl -fsSL -o "$scanner_dir/$archive" \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
-          echo "${GITLEAKS_SHA256}  ${scanner_dir}/${archive}" | sha256sum --check --strict
-          tar -xzf "$scanner_dir/$archive" -C "$scanner_dir"
-
-          # Fetch the proposed revision as Git data and verify it against the
-          # PR payload. The scanner runs only the checksum-verified binary;
-          # it never executes code, workflow files, or configuration from HEAD.
-          git fetch --no-tags --depth=1 origin "$BASE_SHA"
-          git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-head"
-          test "$(git rev-parse "$BASE_SHA")" = "$BASE_SHA"
-          test "$(git rev-parse refs/remotes/origin/pr-head)" = "$HEAD_SHA"
-
-          # Extract only added lines from the trusted SHA-to-SHA diff. The
-          # --no-git file scan has no access to the checkout; executing from
-          # scanner_dir and unsetting config variables force Gitleaks' built-in
-          # rules rather than a PR-controlled .gitleaks.toml/.gitleaksignore.
-          git diff --no-ext-diff --unified=0 "$BASE_SHA" "$HEAD_SHA" -- \
-            | awk '
-                /^@@ / { in_hunk = 1; next }
-                in_hunk && /^\+/ { sub(/^\+/, ""); print }
-              ' > "$scanner_dir/proposed.diff"
-          (
-            cd "$scanner_dir"
-            env -u GITLEAKS_CONFIG -u GITLEAKS_CONFIG_TOML ./gitleaks detect \
-              --no-git \
-              --source "$scanner_dir/proposed.diff" \
-              --gitleaks-ignore-path "$scanner_dir" \
-              --no-banner \
-              --no-color \
-              --redact \
-              --exit-code 1
-          )
+        run: bash base/scripts/ci/scan_added_diff_with_gitleaks.sh "$GITHUB_WORKSPACE"
 
   critical:
     name: critical GitOps guard
@@ -431,6 +185,13 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Check out trusted GitOps validation helpers
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ needs.detect.outputs.base_sha }}
+          path: base
+          persist-credentials: false
+
       - name: Install kustomize
         run: |
           set -euo pipefail
@@ -443,53 +204,16 @@ jobs:
 
       - name: Render Kustomize targets without plugins or networked functions
         run: |
-          set -euo pipefail
-          targets=(
-            clusters/kyrion
-            apps/kyrion/ai
-            apps/kyrion/airflow
-            apps/kyrion/arkham
-            apps/kyrion/coder
-            apps/kyrion/default
-            apps/kyrion/fission
-            apps/kyrion/n8n
-            apps/kyrion/raiplaysoundrss
-            apps/kyrion/registry
-            apps/kyrion/romm
-            infrastructure/controllers
-            infrastructure/configs
-            clusters/kyrion/infrastructure/controllers
-            clusters/kyrion/infrastructure/configs
-            monitoring/controllers
-            clusters/kyrion/monitoring/controllers
-            monitoring/configs
-          )
-          export KUSTOMIZE_PLUGIN_HOME="$RUNNER_TEMP/disabled-kustomize-plugins"
-          mkdir -p rendered
-          for target in "${targets[@]}"; do
-            slug="${target//\//-}"
-            if [ ! -f "$target/kustomization.yaml" ] && [ ! -f "$target/kustomization.yml" ] && [ ! -f "$target/Kustomization" ]; then
-              temporary="$RUNNER_TEMP/$slug"
-              mkdir -p "$temporary"
-              cp -a "$target/." "$temporary/"
-              (cd "$temporary" && kustomize create --autodetect --recursive)
-              kustomize build "$temporary" > "rendered/$slug.yaml"
-            else
-              kustomize build "$target" > "rendered/$slug.yaml"
-            fi
-          done
+          bash base/scripts/ci/render_kustomize_targets.sh \
+            --root "$GITHUB_WORKSPACE" \
+            --output rendered \
+            --temp-root "$RUNNER_TEMP"
 
       - name: Set up Flux CLI
         uses: fluxcd/flux2/action@889be9d6cc8afa8ed639e1e1ba4ab678e3b38d8c # v2.9.4
 
       - name: Build Flux Kustomizations
-        run: |
-          set -euo pipefail
-          flux build kustomization apps --path ./apps/kyrion --kustomization-file clusters/kyrion/apps.yaml --dry-run > rendered/flux-apps.yaml
-          flux build kustomization infra-controllers --path ./clusters/kyrion/infrastructure/controllers --kustomization-file clusters/kyrion/infrastructure.yaml --dry-run > rendered/flux-infra-controllers.yaml
-          flux build kustomization infra-configs --path ./clusters/kyrion/infrastructure/configs --kustomization-file clusters/kyrion/infrastructure.yaml --dry-run > rendered/flux-infra-configs.yaml
-          flux build kustomization monitoring-controllers --path ./clusters/kyrion/monitoring/controllers --kustomization-file clusters/kyrion/monitoring.yaml --dry-run > rendered/flux-monitoring-controllers.yaml
-          flux build kustomization monitoring-configs --path ./monitoring/configs --kustomization-file clusters/kyrion/monitoring.yaml --dry-run > rendered/flux-monitoring-configs.yaml
+        run: bash base/scripts/ci/build_flux_kustomizations.sh --root "$GITHUB_WORKSPACE" --output rendered
 
       - name: Install kubeconform
         run: |
@@ -566,26 +290,18 @@ jobs:
           persist-credentials: false
 
       - name: Fetch and identify changed templates
-        id: templates
         env:
           BASE_SHA: ${{ needs.detect.outputs.base_sha }}
           HEAD_SHA: ${{ needs.detect.outputs.head_sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "$BASE_SHA"
-          git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-head"
-          test "$(git rev-parse refs/remotes/origin/pr-head)" = "$HEAD_SHA"
-          templates="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- coder/templates/ \
-            | sed -nE 's#^coder/templates/([^/]+)/.*#\1#p' | sort -u)"
-          # Tier 0 guardrail changes force every domain validator. When no Coder
-          # template changed, validate every current template instead of failing
-          # the selected Coder job merely because its diff is empty.
-          if [ -z "$templates" ]; then
-            templates="$(find coder/templates -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)"
-          fi
-          test -n "$templates"
-          printf '%s\n' "$templates" > "$RUNNER_TEMP/changed-coder-templates"
+          python3 base/scripts/ci/collect_changed_coder_templates.py \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --pr-number "$PR_NUMBER" \
+            --output "$RUNNER_TEMP/changed-coder-templates"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
@@ -596,17 +312,9 @@ jobs:
         env:
           TF_IN_AUTOMATION: "true"
         run: |
-          set -euo pipefail
-          while IFS= read -r template; do
-            directory="coder/templates/$template"
-            if [ ! -d "$directory" ]; then
-              echo "::error::Changed Coder template was removed: $directory"
-              exit 1
-            fi
-            terraform -chdir="$directory" fmt -check -recursive
-            terraform -chdir="$directory" init -backend=false -input=false
-            terraform -chdir="$directory" validate -no-color
-          done < "$RUNNER_TEMP/changed-coder-templates"
+          bash base/scripts/ci/validate_coder_templates.sh \
+            --root "$GITHUB_WORKSPACE" \
+            --template-file "$RUNNER_TEMP/changed-coder-templates"
 
       - name: Scan changed templates (advisory pending issue #65)
         uses: bridgecrewio/checkov-action@9b70310bcd306d11740313070b940167d6b23085 # v12.3115.0
@@ -654,14 +362,7 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y shellcheck
-          for script in scripts/*.sh; do
-            [ -f "$script" ] || continue
-            case "$(head -n 1 "$script")" in
-              *"/bin/sh"*) sh -n "$script" ;;
-              *) bash -n "$script" ;;
-            esac
-          done
-          shellcheck scripts/*.sh
+          bash base/scripts/ci/lint_shell_scripts.sh --root "$GITHUB_WORKSPACE"
 
   functions:
     name: Functions specification validation

--- a/.github/workflows/pr-validate-ci-helpers.yml
+++ b/.github/workflows/pr-validate-ci-helpers.yml
@@ -1,0 +1,44 @@
+name: PR Validate CI Helpers
+
+# This is deliberately a non-privileged pull_request workflow. It executes the
+# proposed helper tests without production secrets or write permissions, while
+# PR Gate continues to invoke only trusted-base helpers under pull_request_target.
+on:
+  pull_request:
+    paths:
+      - scripts/ci/**
+      - tests/ci/**
+      - .github/workflows/pr-gate.yml
+      - .github/workflows/pr-validate-ci-helpers.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out proposed helper code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install static validation dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y python3-yaml shellcheck
+
+      - name: Compile and test proposed Python helpers
+        run: |
+          python3 -m py_compile scripts/ci/*.py tests/ci/test_pr_gate_helpers.py
+          python3 -m unittest tests.ci.test_pr_gate_helpers
+
+      - name: Parse and lint proposed shell helpers
+        run: |
+          bash -n scripts/ci/*.sh
+          shellcheck scripts/ci/*.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ This repo has no application build/test suite — "validation" means rendering m
 - **Render exactly what Flux will apply**: `flux build kustomization apps --path clusters/kyrion`
 - **Render a HelmRelease's chart** (when adding/upgrading one): `helm template <name> <chart> -f values.yaml`
 - **Lint YAML**: `yamllint .` (config in `.yamllint.yaml`; `.md` files and `clusters/*/flux-system/` are excluded)
+- **Test PR Gate helpers**: `python3 -m unittest tests.ci.test_pr_gate_helpers tests.ci.test_critical_change_guard`; syntax/lint: `python3 -m py_compile scripts/ci/*.py tests/ci/*.py && bash -n scripts/ci/*.sh && shellcheck scripts/ci/*.sh`. Helpers used by `pull_request_target` must be invoked from the trusted base checkout, not from proposed PR content.
 - **Validate `renovate.json`**: `renovate-config-validator` (Renovate CLI is preinstalled in the devcontainer via `ghcr.io/devcontainers-extra/features/renovate-cli:2`; outside the devcontainer, run `npx --yes --package renovate -- renovate-config-validator` instead)
 - **Dry-run Renovate locally** (see what updates it would open, without pushing anything): `LOG_LEVEL=debug RENOVATE_PLATFORM=local renovate` from the repo root
 - **Lint a local Helm chart** (`charts/cron-job`, `charts/onechart`): `ct lint --config ct.yaml --target-branch main` (or `helm lint <chart>` for a single chart without `ct`)

--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -5,28 +5,25 @@ See `AGENTS.md` for the full command reference used by these workflows.
 
 ## Current merge boundary
 
-The repository is moving to one always-present monorepo workflow:
-**`PR Gate / required`**. It detects the paths changed by a PR, runs baseline and
-applicable domain validators, and fails closed when a selected validator does not
-succeed. The ruleset requires this one context rather than path-filtered workflow
-contexts.
+The repository uses one always-present monorepo workflow: **PR Gate**. Its
+**`required`** job detects the paths changed by a PR, runs baseline and applicable
+domain validators, and fails closed when a selected validator does not succeed. The
+ruleset requires this one job context rather than path-filtered workflow contexts.
 
-The legacy path-filtered workflows remain temporarily for diagnostic continuity
-while the ruleset is migrated, but they are not merge requirements. Do not add
-their individual job names as additional required checks; once the GitHub ruleset
-requires `PR Gate / required`, they can be retired in a follow-up PR. See [Merge
-and auto-merge policy](merge-and-automerge-policy.md) for the agent flow and
-[Destructive GitOps changes](../runbooks/destructive-gitops-change.md) for the R2
-procedure.
+The legacy path-filtered workflows remain temporarily for diagnostic continuity,
+but they are not merge requirements. Do not add their individual job names as
+additional required checks. Retire them only in a follow-up PR after confirming the
+PR Gate continues to cover each legacy validation domain. See [Merge and auto-merge
+policy](merge-and-automerge-policy.md) for the agent flow and [Destructive GitOps
+changes](../runbooks/destructive-gitops-change.md) for the R2 procedure.
 
 ## `PR Gate` fan-in behavior
 
-The target ruleset configuration is intentionally enabled only after this workflow
-has reached the default branch and passed a test PR. Before configuring the
-server-side required context, maintainers must use a documentation-only PR to
-verify baseline and critical success plus intentional skips by the conditional
-validators. Until that server-side step is complete, the workflow is diagnostic and
-repository policy still requires agents to use PRs and native auto-merge voluntarily.
+The repository ruleset requires the `required` job from this workflow after the
+workflow reached the default branch and passed the documentation-only rollout PR
+#95. That rollout verified baseline and critical success, intentional skips by the
+conditional validators, and the final fail-closed fan-in. The legacy path-filtered
+workflows remain diagnostic only; they are not merge requirements.
 
 `pr-gate.yml` is loaded from the trusted default branch with
 `pull_request_target`. It checks out the proposed head SHA only as data, uses
@@ -47,6 +44,29 @@ prevents an enforcement-boundary change from being validated by only its own
 narrow job. The Coder validator consequently validates every current template when
 Tier 0 changes select that domain.
 
+### Trusted PR Gate helpers
+
+The security-sensitive logic that would otherwise make `pr-gate.yml` difficult to
+review lives under `scripts/ci/` with focused tests under `tests/ci/`. The
+`pull_request_target` PR Gate always invokes helpers from its trusted base checkout
+(`base/scripts/ci/...`); it never executes a helper from the proposed checkout.
+The non-privileged `PR Validate CI Helpers` workflow runs the proposed helper tests
+on PRs that change those files.
+
+Run the equivalent checks locally before opening such a PR:
+
+```bash
+python3 -m py_compile scripts/ci/*.py tests/ci/*.py
+python3 -m unittest tests.ci.test_pr_gate_helpers tests.ci.test_critical_change_guard
+bash -n scripts/ci/*.sh
+shellcheck scripts/ci/*.sh
+```
+
+The helpers deliberately treat PR manifests, YAML, Terraform, rendered output, and
+Git diffs as data. In particular, the Secret and Gitleaks helpers operate on explicit
+verified SHA-to-SHA Git data; they do not load a PR-controlled `.gitleaks*` file or
+execute PR scripts.
+
 ## Level 1 — repository-wide checks (always run on every PR)
 
 ### YAML lint (`pr-lint-yaml.yml`)
@@ -66,8 +86,8 @@ Tier 0 changes select that domain.
 also included in the filter so changes to its logic are validated too). Note that this
 `paths:` filter is trigger-level only — it does not make this workflow safe to mark as a
 required status check in branch protection, since a PR that doesn't touch these paths
-would leave the check permanently "Pending" and block merge; see #67 for the fan-in
-"gate" job refactor needed before this workflow can be required.
+would leave the check permanently "Pending" and block merge. The always-present PR
+Gate supplies the merge requirement instead.
 
 Validates the vendored Helm charts (`charts/cron-job`, `charts/onechart`):
 
@@ -104,9 +124,8 @@ directory is an independent Terraform root module (no remote backend, no shared 
 
 > **Note:** the `paths:` filter above only controls when the workflow *triggers* — it does not make
 > this workflow safe to mark as a required status check in branch protection. A PR that touches
-> neither filtered path leaves the check permanently "Pending", which blocks merge. See
-> [#67](https://github.com/alecsg77/elysium/issues/67) for the proper fix (a fan-in "gate" job
-> pattern).
+> neither filtered path leaves the check permanently "Pending", which blocks merge. The
+> always-present PR Gate supplies the merge requirement instead.
 
 The workflow first computes which template directories were touched by the PR (diffing the PR's
 base and head refs, same approach as the `init` job in `publish-coder-templates.yaml` but adapted to
@@ -150,7 +169,8 @@ checkov -d . --framework terraform --soft-fail
 **Workflow:** `.github/workflows/pr-validate-flux.yml`
 **Trigger:** `pull_request` on changes under `clusters/**`, `infrastructure/**`, `apps/**`, or
 `monitoring/**`, as well as changes to this workflow file. Like the other path-filtered workflows,
-it must **not** be a required status check until #67 introduces an always-running fan-in gate.
+it must **not** be an individual required status check: the always-running PR Gate
+provides the merge requirement instead.
 
 The workflow validates the core GitOps directories with four jobs:
 

--- a/scripts/ci/build_flux_kustomizations.sh
+++ b/scripts/ci/build_flux_kustomizations.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Build the fixed Flux Kustomizations evaluated by PR Gate.
+set -euo pipefail
+
+root="."
+output="rendered"
+
+while (($#)); do
+  case "$1" in
+    --root)
+      root="$2"
+      shift 2
+      ;;
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 [--root DIRECTORY] [--output DIRECTORY]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+root="$(cd "$root" && pwd)"
+mkdir -p "$output"
+output="$(cd "$output" && pwd)"
+
+cd "$root"
+flux build kustomization apps \
+  --path ./apps/kyrion \
+  --kustomization-file clusters/kyrion/apps.yaml \
+  --dry-run > "$output/flux-apps.yaml"
+flux build kustomization infra-controllers \
+  --path ./clusters/kyrion/infrastructure/controllers \
+  --kustomization-file clusters/kyrion/infrastructure.yaml \
+  --dry-run > "$output/flux-infra-controllers.yaml"
+flux build kustomization infra-configs \
+  --path ./clusters/kyrion/infrastructure/configs \
+  --kustomization-file clusters/kyrion/infrastructure.yaml \
+  --dry-run > "$output/flux-infra-configs.yaml"
+flux build kustomization monitoring-controllers \
+  --path ./clusters/kyrion/monitoring/controllers \
+  --kustomization-file clusters/kyrion/monitoring.yaml \
+  --dry-run > "$output/flux-monitoring-controllers.yaml"
+flux build kustomization monitoring-configs \
+  --path ./monitoring/configs \
+  --kustomization-file clusters/kyrion/monitoring.yaml \
+  --dry-run > "$output/flux-monitoring-configs.yaml"

--- a/scripts/ci/check_changed_secrets.py
+++ b/scripts/ci/check_changed_secrets.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Reject changed plaintext Kubernetes Secret manifests from a verified PR diff.
+
+The helper is executed from the trusted base checkout. Proposed content is read
+only by explicit Git object ID and never through a PR-controlled script/config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import yaml
+
+
+ROOTS = ("apps", "clusters", "infrastructure", "monitoring", "functions")
+EXCEPTION_PATH = "infrastructure/configs/ci/copilot-agent-rbac/secret.yaml"
+
+
+class SecretCheckError(RuntimeError):
+    """A malformed diff or YAML input that must fail the PR."""
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate mapping keys."""
+
+
+def construct_mapping(loader: UniqueKeyLoader, node: yaml.MappingNode, deep: bool = False) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise yaml.YAMLError(f"duplicate mapping key: {key!r}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueKeyLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path("."), help="PR head checkout used only as a Git object database")
+    parser.add_argument("--base-sha", required=True, help="Trusted base SHA")
+    parser.add_argument("--head-sha", required=True, help="Proposed head SHA")
+    parser.add_argument("--pr-number", required=True, help="PR number used to verify the fetched head")
+    parser.add_argument("--skip-fetch", action="store_true", help=argparse.SUPPRESS)
+    return parser.parse_args()
+
+
+def git(repo: Path, *arguments: str) -> bytes:
+    completed = subprocess.run(
+        ["git", *arguments], cwd=repo, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise SecretCheckError(f"Unable to calculate the trusted base/head diff: {detail}")
+    return completed.stdout
+
+
+def verified_revisions(args: argparse.Namespace) -> None:
+    if not args.skip_fetch:
+        git(args.repo, "fetch", "--no-tags", "--depth=1", "origin", args.base_sha)
+        git(
+            args.repo,
+            "fetch",
+            "--no-tags",
+            "--depth=1",
+            "origin",
+            f"pull/{args.pr_number}/head:refs/remotes/origin/pr-head",
+        )
+    if git(args.repo, "rev-parse", "HEAD").decode().strip() != args.head_sha:
+        raise SecretCheckError("Proposed checkout HEAD does not match the PR head SHA")
+    if git(args.repo, "rev-parse", args.base_sha).decode().strip() != args.base_sha:
+        raise SecretCheckError("Trusted base SHA could not be resolved")
+    if not args.skip_fetch and git(args.repo, "rev-parse", "refs/remotes/origin/pr-head").decode().strip() != args.head_sha:
+        raise SecretCheckError("Fetched pull-request head does not match the PR payload")
+
+
+def changed_yaml_paths(repo: Path, base_sha: str, head_sha: str) -> list[str]:
+    raw_diff = git(
+        repo,
+        "diff",
+        "--name-status",
+        "-z",
+        "--find-renames",
+        "--find-copies",
+        "--diff-filter=ACMR",
+        base_sha,
+        head_sha,
+        "--",
+        *ROOTS,
+    )
+    fields = raw_diff.split(b"\0")
+    if fields and fields[-1] == b"":
+        fields.pop()
+
+    paths: list[str] = []
+    index = 0
+    while index < len(fields):
+        try:
+            status = fields[index].decode("ascii")
+        except UnicodeDecodeError as error:
+            raise SecretCheckError("Trusted diff returned a non-ASCII status") from error
+        index += 1
+        if not status or status[0] not in "ACMR":
+            raise SecretCheckError(f"Trusted diff returned an unexpected status: {status!r}")
+        if status[0] in "RC":
+            if index + 1 >= len(fields):
+                raise SecretCheckError("Trusted diff ended while reading a rename or copy")
+            index += 1  # Old path; only the proposed destination is checked.
+        if index >= len(fields):
+            raise SecretCheckError("Trusted diff ended while reading a changed path")
+        try:
+            path = fields[index].decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise SecretCheckError("Trusted diff contains a non-UTF-8 path") from error
+        index += 1
+        candidate = PurePosixPath(path)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise SecretCheckError(f"Trusted diff returned an unsafe path: {path}")
+        if not any(path == root or path.startswith(f"{root}/") for root in ROOTS):
+            raise SecretCheckError(f"Trusted diff returned a path outside the GitOps roots: {path}")
+        if path.lower().endswith((".yaml", ".yml")):
+            paths.append(path)
+    return paths
+
+
+def exact_service_account_token_exception(document: Any) -> bool:
+    return (
+        isinstance(document, dict)
+        and set(document) == {"apiVersion", "kind", "metadata", "type"}
+        and document["apiVersion"] == "v1"
+        and document["kind"] == "Secret"
+        and document["type"] == "kubernetes.io/service-account-token"
+        and document["metadata"]
+        == {
+            "name": "copilot-agent-readonly-token",
+            "namespace": "arc-runners",
+            "annotations": {"kubernetes.io/service-account.name": "copilot-agent-readonly"},
+        }
+    )
+
+
+def find_secret_mappings(value: Any, seen: set[int] | None = None) -> list[dict[str, Any]]:
+    if seen is None:
+        seen = set()
+    if isinstance(value, (dict, list)):
+        if id(value) in seen:
+            return []
+        seen.add(id(value))
+    if isinstance(value, dict):
+        matches = [value] if value.get("kind") == "Secret" else []
+        for child in value.values():
+            matches.extend(find_secret_mappings(child, seen))
+        return matches
+    if isinstance(value, list):
+        matches: list[dict[str, Any]] = []
+        for child in value:
+            matches.extend(find_secret_mappings(child, seen))
+        return matches
+    return []
+
+
+def check_changed_secrets(repo: Path, base_sha: str, head_sha: str) -> None:
+    for path in changed_yaml_paths(repo, base_sha, head_sha):
+        try:
+            content = git(repo, "show", f"{head_sha}:{path}")
+            documents = list(yaml.load_all(content, Loader=UniqueKeyLoader))
+        except (yaml.YAMLError, UnicodeDecodeError) as error:
+            raise SecretCheckError(f"Could not parse changed YAML document {path}: {error}") from error
+        secret_documents = [secret for document in documents for secret in find_secret_mappings(document)]
+        if not secret_documents:
+            continue
+        if (
+            path == EXCEPTION_PATH
+            and len(documents) == 1
+            and len(secret_documents) == 1
+            and secret_documents[0] is documents[0]
+            and exact_service_account_token_exception(documents[0])
+        ):
+            continue
+        raise SecretCheckError(
+            f"Bare kind: Secret manifest in {path} is forbidden; use SealedSecret or a consumer-native Secret reference."
+        )
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        verified_revisions(args)
+        check_changed_secrets(args.repo, args.base_sha, args.head_sha)
+    except SecretCheckError as error:
+        print(f"::error::{error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/collect_changed_coder_templates.py
+++ b/scripts/ci/collect_changed_coder_templates.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Write PR Gate's changed Coder template list from verified Git revisions.
+
+This helper is invoked from the trusted base checkout. Template directories in the
+proposed checkout are data only; no Terraform or PR-controlled script is run here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path("."), help="Proposed checkout containing the Git object database")
+    parser.add_argument("--base-sha", required=True, help="Trusted base SHA")
+    parser.add_argument("--head-sha", required=True, help="Proposed PR head SHA")
+    parser.add_argument("--pr-number", required=True, help="Pull request number used to verify the head")
+    parser.add_argument("--output", type=Path, required=True, help="File to receive one template directory name per line")
+    return parser.parse_args()
+
+
+def git(repo: Path, *arguments: str) -> bytes:
+    completed = subprocess.run(
+        ["git", *arguments], cwd=repo, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"git {' '.join(arguments)} failed: {detail}")
+    return completed.stdout
+
+
+def changed_templates(repo: Path, base_sha: str, head_sha: str) -> list[str]:
+    changed = git(repo, "diff", "--name-only", "-z", base_sha, head_sha, "--", "coder/templates/")
+    templates = {
+        path.decode("utf-8").split("/", 3)[2]
+        for path in changed.split(b"\0")
+        if path and path.startswith(b"coder/templates/") and len(path.split(b"/")) >= 3
+    }
+    return sorted(templates)
+
+
+def all_templates(repo: Path) -> list[str]:
+    directory = repo / "coder/templates"
+    if not directory.is_dir():
+        raise RuntimeError(f"Coder template directory is missing: {directory}")
+    return sorted(path.name for path in directory.iterdir() if path.is_dir())
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        git(args.repo, "fetch", "--no-tags", "--depth=1", "origin", args.base_sha)
+        git(
+            args.repo,
+            "fetch",
+            "--no-tags",
+            "--depth=1",
+            "origin",
+            f"pull/{args.pr_number}/head:refs/remotes/origin/pr-head",
+        )
+        if git(args.repo, "rev-parse", "refs/remotes/origin/pr-head").decode().strip() != args.head_sha:
+            raise RuntimeError("Fetched pull-request head does not match the PR payload")
+        templates = changed_templates(args.repo, args.base_sha, args.head_sha) or all_templates(args.repo)
+        if not templates:
+            raise RuntimeError("No Coder templates are available to validate")
+    except (RuntimeError, UnicodeDecodeError) as error:
+        print(f"::error::Unable to identify Coder templates: {error}", file=sys.stderr)
+        return 1
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(templates) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/detect_pr_gate_domains.py
+++ b/scripts/ci/detect_pr_gate_domains.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Classify a pull request into PR Gate validation domains.
+
+This helper is executed from the trusted base checkout by the pull_request_target
+workflow. It only reads the proposed revision through verified Git object IDs and
+writes GitHub step outputs; it never checks out or executes PR-controlled files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+DOMAIN_NAMES = ("gitops", "helm", "coder", "actions", "functions")
+TIER0_FILES = {
+    ".github/CODEOWNERS",
+    ".github/actionlint.yaml",
+    ".github/critical-resources.yaml",
+}
+TIER0_PREFIXES = (".github/workflows/", "scripts/ci/")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path("."), help="Trusted checkout containing the Git remote")
+    parser.add_argument("--base-sha", required=True, help="Trusted PR base SHA")
+    parser.add_argument("--head-sha", required=True, help="Proposed PR head SHA")
+    parser.add_argument("--pr-number", required=True, help="Pull request number used to fetch the head")
+    parser.add_argument("--github-output", type=Path, required=True, help="GitHub step output file")
+    return parser.parse_args()
+
+
+def classify_paths(paths: Iterable[str]) -> dict[str, bool]:
+    """Return applicable validator domains for the given changed paths."""
+    result = {name: False for name in DOMAIN_NAMES}
+    for path in paths:
+        if path.startswith(("clusters/", "infrastructure/", "apps/", "monitoring/")):
+            result["gitops"] = True
+        if path.startswith("charts/") or path == "ct.yaml":
+            result["helm"] = True
+        if path.startswith("coder/templates/"):
+            result["coder"] = True
+        if path.startswith((".github/workflows/", ".github/actions/", "scripts/")):
+            result["actions"] = True
+        if path.startswith("functions/"):
+            result["functions"] = True
+        if path in TIER0_FILES or path.startswith(TIER0_PREFIXES):
+            return {name: True for name in DOMAIN_NAMES}
+    return result
+
+
+def git(repo: Path, *arguments: str) -> bytes:
+    completed = subprocess.run(
+        ["git", *arguments], cwd=repo, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"git {' '.join(arguments)} failed: {detail}")
+    return completed.stdout
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        git(
+            args.repo,
+            "fetch",
+            "--no-tags",
+            "--depth=1",
+            "origin",
+            f"pull/{args.pr_number}/head:refs/remotes/origin/pr-head",
+        )
+        checked_out_base = git(args.repo, "rev-parse", "HEAD").decode().strip()
+        if checked_out_base != args.base_sha:
+            raise RuntimeError(f"trusted checkout {checked_out_base} does not match {args.base_sha}")
+        fetched_head = git(args.repo, "rev-parse", "refs/remotes/origin/pr-head").decode().strip()
+        if fetched_head != args.head_sha:
+            raise RuntimeError(f"fetched pull-request head {fetched_head} does not match {args.head_sha}")
+        changed = git(args.repo, "diff", "--name-only", "-z", args.base_sha, args.head_sha)
+        paths = [path.decode("utf-8") for path in changed.split(b"\0") if path]
+        domains = classify_paths(paths)
+    except (RuntimeError, UnicodeDecodeError) as error:
+        print(f"::error::Unable to classify PR Gate validation domains: {error}", file=sys.stderr)
+        return 1
+
+    lines = [f"base_sha={args.base_sha}", f"head_sha={args.head_sha}"]
+    lines.extend(f"{domain}={'true' if domains[domain] else 'false'}" for domain in DOMAIN_NAMES)
+    args.github_output.parent.mkdir(parents=True, exist_ok=True)
+    with args.github_output.open("a", encoding="utf-8") as output:
+        output.write("\n".join(lines) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/lint_shell_scripts.sh
+++ b/scripts/ci/lint_shell_scripts.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Parse and ShellCheck shell scripts without sourcing or executing them.
+set -euo pipefail
+
+root="."
+if [[ ${1:-} == "--root" ]]; then
+  root="$2"
+  shift 2
+fi
+if (($#)); then
+  echo "Usage: $0 [--root DIRECTORY]" >&2
+  exit 2
+fi
+
+root="$(cd "$root" && pwd)"
+mapfile -d '' scripts < <(find "$root/scripts" -type f -name '*.sh' -print0 | sort -z)
+test "${#scripts[@]}" -gt 0
+
+for script in "${scripts[@]}"; do
+  case "$(head -n 1 "$script")" in
+    *"/bin/sh"*) sh -n "$script" ;;
+    *) bash -n "$script" ;;
+  esac
+done
+shellcheck "${scripts[@]}"

--- a/scripts/ci/parse_yaml_paths.py
+++ b/scripts/ci/parse_yaml_paths.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Parse selected YAML trees without executing configuration from those trees."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path("."), help="Tree containing YAML data to parse")
+    parser.add_argument("--directory", action="append", required=True, help="Directory relative to --root")
+    return parser.parse_args()
+
+
+def yaml_paths(root: Path, directories: list[str]) -> list[Path]:
+    paths: list[Path] = []
+    for relative in directories:
+        directory = root / relative
+        if not directory.is_dir():
+            raise ValueError(f"YAML directory is missing: {directory}")
+        paths.extend(directory.rglob("*.yaml"))
+    return sorted(paths)
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        for path in yaml_paths(args.root, args.directory):
+            with path.open(encoding="utf-8") as stream:
+                list(yaml.safe_load_all(stream))
+    except (OSError, ValueError, yaml.YAMLError) as error:
+        print(f"::error::Could not parse YAML data: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/render_kustomize_targets.sh
+++ b/scripts/ci/render_kustomize_targets.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Render the fixed PR Gate Kustomize target set without plugins or Helm inflation.
+# This trusted helper treats the requested repository tree as inert Kustomize input.
+set -euo pipefail
+
+root="."
+output="rendered"
+temp_root="${RUNNER_TEMP:-/tmp}"
+
+while (($#)); do
+  case "$1" in
+    --root)
+      root="$2"
+      shift 2
+      ;;
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    --temp-root)
+      temp_root="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 [--root DIRECTORY] [--output DIRECTORY] [--temp-root DIRECTORY]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+root="$(cd "$root" && pwd)"
+mkdir -p "$output"
+output="$(cd "$output" && pwd)"
+mkdir -p "$temp_root"
+workspace="$(mktemp -d "$temp_root/kustomize-render.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+# Do not load Kustomize exec plugins/functions from the proposed checkout.
+export KUSTOMIZE_PLUGIN_HOME="$workspace/disabled-kustomize-plugins"
+
+targets=(
+  clusters/kyrion
+  apps/kyrion/ai
+  apps/kyrion/airflow
+  apps/kyrion/arkham
+  apps/kyrion/coder
+  apps/kyrion/default
+  apps/kyrion/fission
+  apps/kyrion/n8n
+  apps/kyrion/raiplaysoundrss
+  apps/kyrion/registry
+  apps/kyrion/romm
+  infrastructure/controllers
+  infrastructure/configs
+  clusters/kyrion/infrastructure/controllers
+  clusters/kyrion/infrastructure/configs
+  monitoring/controllers
+  clusters/kyrion/monitoring/controllers
+  monitoring/configs
+)
+
+for target in "${targets[@]}"; do
+  source="$root/$target"
+  test -d "$source"
+  slug="${target//\//-}"
+  if [[ ! -f "$source/kustomization.yaml" && ! -f "$source/kustomization.yml" && ! -f "$source/Kustomization" ]]; then
+    temporary="$workspace/$slug"
+    mkdir -p "$temporary"
+    cp -a "$source/." "$temporary/"
+    (
+      cd "$temporary"
+      kustomize create --autodetect --recursive
+    )
+    kustomize build "$temporary" > "$output/$slug.yaml"
+  else
+    kustomize build "$source" > "$output/$slug.yaml"
+  fi
+done

--- a/scripts/ci/scan_added_diff_with_gitleaks.sh
+++ b/scripts/ci/scan_added_diff_with_gitleaks.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Scan only additions from a verified base-to-head diff with trusted Gitleaks.
+# This helper is invoked from the trusted base checkout by pull_request_target.
+set -euo pipefail
+
+: "${BASE_SHA:?BASE_SHA is required}"
+: "${HEAD_SHA:?HEAD_SHA is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${GITLEAKS_VERSION:?GITLEAKS_VERSION is required}"
+: "${GITLEAKS_SHA256:?GITLEAKS_SHA256 is required}"
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+
+repo="${1:-.}"
+scanner_dir="$RUNNER_TEMP/gitleaks"
+archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+
+mkdir -p "$scanner_dir"
+curl -fsSL -o "$scanner_dir/$archive" \
+  "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
+echo "${GITLEAKS_SHA256}  ${scanner_dir}/${archive}" | sha256sum --check --strict
+tar -xzf "$scanner_dir/$archive" -C "$scanner_dir"
+
+# Fetch the proposed revision as Git data and verify it against the PR payload.
+# The scanner only runs the checksum-verified binary; it never reads a Gitleaks
+# configuration, executable, or workflow file from the proposed revision.
+git -C "$repo" fetch --no-tags --depth=1 origin "$BASE_SHA"
+git -C "$repo" fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-head"
+test "$(git -C "$repo" rev-parse "$BASE_SHA")" = "$BASE_SHA"
+test "$(git -C "$repo" rev-parse refs/remotes/origin/pr-head)" = "$HEAD_SHA"
+
+# The --no-git file scan runs from scanner_dir, with config environment variables
+# unset and its ignore-file lookup confined there. That forces built-in Gitleaks
+# rules instead of PR-controlled .gitleaks.toml or .gitleaksignore content.
+git -C "$repo" diff --no-ext-diff --unified=0 "$BASE_SHA" "$HEAD_SHA" -- \
+  | awk '
+      /^@@ / { in_hunk = 1; next }
+      in_hunk && /^\+/ { sub(/^\+/, ""); print }
+    ' > "$scanner_dir/proposed.diff"
+(
+  cd "$scanner_dir"
+  env -u GITLEAKS_CONFIG -u GITLEAKS_CONFIG_TOML ./gitleaks detect \
+    --no-git \
+    --source "$scanner_dir/proposed.diff" \
+    --gitleaks-ignore-path "$scanner_dir" \
+    --no-banner \
+    --no-color \
+    --redact \
+    --exit-code 1
+)

--- a/scripts/ci/validate_coder_templates.sh
+++ b/scripts/ci/validate_coder_templates.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Run Coder template Terraform validation without backend/session credentials.
+# The helper is trusted; Terraform files under --root are proposed data.
+set -euo pipefail
+
+root="."
+template_file=""
+
+while (($#)); do
+  case "$1" in
+    --root)
+      root="$2"
+      shift 2
+      ;;
+    --template-file)
+      template_file="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 --template-file FILE [--root DIRECTORY]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+test -n "$template_file"
+root="$(cd "$root" && pwd)"
+test -f "$template_file"
+
+while IFS= read -r template; do
+  test -n "$template"
+  case "$template" in
+    */*|.|..|*'..'*)
+      echo "::error::Unsafe Coder template directory name: $template" >&2
+      exit 1
+      ;;
+  esac
+  directory="$root/coder/templates/$template"
+  if [[ ! -d "$directory" ]]; then
+    echo "::error::Changed Coder template was removed: coder/templates/$template" >&2
+    exit 1
+  fi
+  terraform -chdir="$directory" fmt -check -recursive
+  terraform -chdir="$directory" init -backend=false -input=false
+  terraform -chdir="$directory" validate -no-color
+done < "$template_file"

--- a/tests/ci/test_pr_gate_helpers.py
+++ b/tests/ci/test_pr_gate_helpers.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Regression tests for trusted PR Gate helper behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts/ci"
+
+
+def load_module(filename: str):
+    path = SCRIPTS / filename
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+DOMAINS = load_module("detect_pr_gate_domains.py")
+SECRETS = load_module("check_changed_secrets.py")
+
+
+class DomainDetectionTest(unittest.TestCase):
+    def test_docs_only_change_skips_conditional_domains(self) -> None:
+        self.assertEqual(
+            DOMAINS.classify_paths(["docs/ci/pr-validation.md"]),
+            {"gitops": False, "helm": False, "coder": False, "actions": False, "functions": False},
+        )
+
+    def test_tier_zero_helper_change_forces_every_domain(self) -> None:
+        self.assertEqual(
+            DOMAINS.classify_paths(["scripts/ci/check_changed_secrets.py"]),
+            {"gitops": True, "helm": True, "coder": True, "actions": True, "functions": True},
+        )
+
+    def test_domains_are_classified_independently(self) -> None:
+        self.assertEqual(
+            DOMAINS.classify_paths(["apps/base/example/release.yaml", "charts/onechart/values.yaml", "functions/f.yaml"]),
+            {"gitops": True, "helm": True, "coder": False, "actions": False, "functions": True},
+        )
+
+
+class ChangedSecretsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tempdir.name) / "repo"
+        self.repo.mkdir()
+        self.run_git("init")
+        self.run_git("config", "user.email", "ci@example.invalid")
+        self.run_git("config", "user.name", "CI Test")
+        (self.repo / "apps/base/example").mkdir(parents=True)
+        (self.repo / "apps/base/example/config.yaml").write_text("kind: ConfigMap\n", encoding="utf-8")
+        self.commit("base")
+        self.base_sha = self.run_git("rev-parse", "HEAD").stdout.strip()
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def run_git(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *arguments], cwd=self.repo, text=True, capture_output=True, check=True
+        )
+
+    def commit(self, message: str) -> None:
+        self.run_git("add", ".")
+        self.run_git("commit", "-m", message)
+
+    def run_checker(self) -> subprocess.CompletedProcess[str]:
+        head_sha = self.run_git("rev-parse", "HEAD").stdout.strip()
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS / "check_changed_secrets.py"),
+                "--repo",
+                str(self.repo),
+                "--base-sha",
+                self.base_sha,
+                "--head-sha",
+                head_sha,
+                "--pr-number",
+                "1",
+                "--skip-fetch",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def write_and_commit(self, relative: str, content: str) -> None:
+        path = self.repo / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        self.commit("change")
+
+    def test_safe_yaml_passes(self) -> None:
+        self.write_and_commit("apps/base/example/config.yaml", "kind: ConfigMap\nmetadata:\n  name: safe\n")
+        self.assertEqual(self.run_checker().returncode, 0)
+
+    def test_plaintext_secret_fails(self) -> None:
+        self.write_and_commit("apps/base/example/secret.yaml", "apiVersion: v1\nkind: Secret\nmetadata:\n  name: forbidden\n")
+        result = self.run_checker()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Bare kind: Secret manifest", result.stderr)
+
+    def test_nested_secret_fails(self) -> None:
+        self.write_and_commit("apps/base/example/nested.yaml", "items:\n  - kind: Secret\n    metadata:\n      name: forbidden\n")
+        result = self.run_checker()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Bare kind: Secret manifest", result.stderr)
+
+    def test_exact_controller_token_exception_passes(self) -> None:
+        self.write_and_commit(
+            "infrastructure/configs/ci/copilot-agent-rbac/secret.yaml",
+            "apiVersion: v1\nkind: Secret\nmetadata:\n  name: copilot-agent-readonly-token\n  namespace: arc-runners\n  annotations:\n    kubernetes.io/service-account.name: copilot-agent-readonly\ntype: kubernetes.io/service-account-token\n",
+        )
+        self.assertEqual(self.run_checker().returncode, 0)
+
+    def test_controller_token_exception_with_data_fails(self) -> None:
+        self.write_and_commit(
+            "infrastructure/configs/ci/copilot-agent-rbac/secret.yaml",
+            "apiVersion: v1\nkind: Secret\nmetadata:\n  name: copilot-agent-readonly-token\n  namespace: arc-runners\n  annotations:\n    kubernetes.io/service-account.name: copilot-agent-readonly\ntype: kubernetes.io/service-account-token\ndata:\n  token: dGVzdA==\n",
+        )
+        result = self.run_checker()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Bare kind: Secret manifest", result.stderr)
+
+    def test_duplicate_yaml_key_fails_closed(self) -> None:
+        self.write_and_commit("apps/base/example/duplicate.yaml", "kind: ConfigMap\nkind: Secret\n")
+        result = self.run_checker()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Could not parse changed YAML", result.stderr)
+
+
+class YAMLPathParserTest(unittest.TestCase):
+    def test_parser_rejects_missing_directory(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPTS / "parse_yaml_paths.py"), "--root", str(ROOT), "--directory", "missing"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("YAML directory is missing", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Extracts the security-sensitive and high-complexity PR Gate logic from inline workflow blocks into versioned, locally testable helpers under `scripts/ci/`.

The refactor preserves the `pull_request_target` trust boundary: jobs that check out the proposed head invoke only `base/scripts/ci/...` helpers from the trusted PR base. The proposed repository remains data, never executable CI helper code.

Changes include:

- trusted helpers for domain detection, YAML parsing, changed-Secret policy, diff-only Gitleaks scanning, Kustomize/Flux rendering, Coder template selection/validation, and ShellCheck orchestration;
- focused regression tests for domain selection and the fail-closed Secret detector;
- a non-privileged `PR Validate CI Helpers` workflow for proposed helper tests;
- documentation and `AGENTS.md` local-validation guidance;
- Tier 0 policy coverage for all `scripts/ci/**` helpers.

No R2 operation, deployment, cluster mutation, secret rotation, or GitHub settings change is included.

Closes none. Related: #87, #89, #91, #98.

## Local validation

- `python3 -m py_compile scripts/ci/*.py tests/ci/*.py`
- `python3 -m unittest tests.ci.test_pr_gate_helpers tests.ci.test_critical_change_guard` — 28 tests passed
- `bash -n scripts/ci/*.sh`
- `shellcheck scripts/*.sh scripts/ci/*.sh`
- checksum-verified `actionlint` v1.7.9 across workflows
- Gitleaks helper isolated clean-diff smoke test with checksum-verified Gitleaks v8.30.1
- Kustomize helper smoke render (23 artifacts) and Flux helper smoke render
- root Kustomize and Flux builds
- `yamllint`, `renovate-config-validator`, `git diff --check`, and documentation-link check

## Rollback

Revert this PR through a normal PR. Do not bypass the ruleset or mutate the cluster directly.
