### PR TITLE
docs(ci): require approval before auto-merge

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,11 +27,12 @@ Use this file for Copilot-specific operating context and high-signal repository 
 coder templates push <name> ...
 coder template push <name> ...
 
-# ✅ CORRECT — edit files, commit, push to main:
+# ✅ CORRECT — edit files, commit to a feature branch, and open a PR:
 git add coder/templates/<name>/...
 git commit -m "..."
-git push origin main
-# → publish-coder-templates.yaml workflow triggers automatically
+git push origin <feature-branch>
+# → after explicit user approval and PR Gate success, squash auto-merge to main
+#    triggers publish-coder-templates.yaml automatically
 ```
 The `.github/workflows/publish-coder-templates.yaml` workflow handles ALL template publishing:
 - Triggers on push to `main` for any change under `coder/templates/**`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,8 @@
 
 - [ ] I identified the affected domain(s): GitOps, charts, Coder, Actions/scripts, functions, or docs.
 - [ ] I ran the applicable local validation commands and recorded them below.
-- [ ] I enabled native auto-merge with `gh pr merge --auto --squash` (or explained why it is not yet available).
+- [ ] User approval is pending; this PR intentionally has auto-merge disabled.
+- [ ] The user explicitly approved head SHA `<sha>` for merge; I then enabled native auto-merge with `gh pr merge --auto --squash`.
 
 ## Critical / destructive changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,9 +52,12 @@ Vendor-neutral operating guide for AI coding agents working in this repository.
 - Keep documentation authoritative in `/docs`, not duplicated across agent files.
 
 ## Pull Request and Auto-Merge Safety
-- Never commit or push directly to `main`, including when authenticated as a repository administrator. Create a branch, open/update a PR, and enable native squash auto-merge with `gh pr merge --auto --squash`.
+- Never commit or push directly to `main`, including when authenticated as a repository administrator. Agents may commit to a feature branch and open/update a PR after running the applicable validation.
+- Opening a PR is **not** permission to merge it. An agent must not manually merge, enable auto-merge, or otherwise cause a PR to merge until the user explicitly approves the **current proposed changes**. A passing `PR Gate / required`, permission to open a PR, or an earlier approval of a different diff never substitutes for that approval.
+- Explicit approval means a clear user instruction to merge or enable auto-merge after the agent has reported the current PR URL and head SHA. Any pushed commit invalidates prior approval; if auto-merge was already enabled, disable it, report the new head SHA, and obtain fresh approval.
+- After explicit approval, enable native squash auto-merge with `gh pr merge --auto --squash`; do not manually merge. Record whether approval is pending or received, including the approved head SHA, in the PR template.
 - Never use `gh pr merge --admin`, a direct merge API bypass, or a force push as a routine workaround. The only break-glass path is documented in `docs/runbooks/github-break-glass.md`.
-- After the server-side ruleset migration, `PR Gate / required` is the single required monorepo status. It runs only the validation domains applicable to the PR and fails closed on a failed or unexpected skipped validator; until then, agents still follow this PR-only policy and never exploit legacy settings.
+- `PR Gate / required` is the single required monorepo status. It runs only the validation domains applicable to the PR and fails closed on a failed or unexpected skipped validator. Legacy path-filtered checks are diagnostic only and never replace the PR-only merge policy.
 - Treat changes to Flux bootstrap/ownership, Tailscale access resources, secrets, storage, and CI guardrail files as critical. Follow `docs/runbooks/destructive-gitops-change.md` for R2 removals; persistent-data changes additionally require the backup/restore contract in `docs/runbooks/backup-and-restore.md`.
 
 ## Essential Commands

--- a/docs/ci/merge-and-automerge-policy.md
+++ b/docs/ci/merge-and-automerge-policy.md
@@ -2,36 +2,50 @@
 
 ## Purpose
 
-Every normal repository change follows **branch → pull request → native GitHub
-squash auto-merge**. This is a safety boundary for the GitOps control plane: a
-commit must first receive the applicable automated validation before Flux can
-reconcile it.
+Every normal repository change follows **branch → pull request → explicit user
+approval → native GitHub squash auto-merge**. This is a safety boundary for the
+GitOps control plane: a commit must first receive both the applicable automated
+validation and user approval before Flux can reconcile it.
 
-The initial rollout deliberately uses the existing `@alecsg77` administrative
-identity for both the maintainer and coding agents. After the server-side ruleset
-migration, the ruleset—not identity separation—blocks direct updates to `main`.
-Until then, this remains an unmitigated repository-settings gap and agents must
-still follow the PR-only client policy. An administrator can alter repository
-settings only through a documented break-glass event.
+Opening a PR is allowed after the agent has completed applicable local validation,
+but it is a request for review—not authorization to merge. `PR Gate / required`
+proves automated policy compliance; it does not replace explicit user approval of
+the current proposed changes.
+
+The rollout deliberately uses the existing `@alecsg77` administrative identity
+for both the maintainer and coding agents. The server-side ruleset—not identity
+separation—blocks direct updates to `main`; agents must still follow this PR-only
+policy even when an administrative break-glass path exists. Repository settings
+may be altered only through a documented break-glass event.
 
 ## Required agent flow
 
 1. Create or update a non-`main` branch.
-2. Push only that branch.
-3. Open or update a PR targeting `main`.
-4. Enable native auto-merge with:
+2. Run the applicable local validation, commit, and push only that branch.
+3. Open or update a PR targeting `main`. If the user has not explicitly approved
+   the current diff, leave auto-merge disabled and mark approval as pending in the
+   PR template.
+4. Report the PR URL, head SHA, validated scope, and any remaining risk to the
+   user. Wait for an explicit approval that this **current head SHA** may merge.
+5. Only after that approval, record the approved head SHA in the PR template and
+   enable native squash auto-merge with:
 
    ```bash
    gh pr merge --auto --squash
    ```
 
-5. Never use `--admin`, force-push `main`, or merge through a direct Git push.
-6. Observe the PR until `PR Gate / required` is successful and auto-merge has
+6. If any new commit is pushed after approval, disable auto-merge if it was
+   already enabled, return to step 3, and obtain fresh approval. Do not treat
+   approval of an earlier head SHA as approval of a changed PR.
+7. Never use `--admin`, force-push `main`, manually merge, or merge through a
+   direct Git push.
+8. Observe the PR until `PR Gate / required` is successful and auto-merge has
    completed. If it fails, correct the PR; do not bypass the ruleset.
 
-`CODEOWNERS` assigns the repository to `@alecsg77` for ownership visibility. No
-review approval is required in this first phase; the fail-closed automated gate
-is the merge condition.
+`CODEOWNERS` assigns the repository to `@alecsg77` for ownership visibility.
+GitHub review approvals remain optional in this phase. The agent-facing explicit
+user approval above is a separate merge authorization and is required even when
+the ruleset requires zero GitHub approvals.
 
 ## Monorepo gate
 
@@ -48,9 +62,9 @@ ruleset is migrated. It always runs and:
   that domain as not applicable.
 
 Do not add a separate required check with a generic name such as `gate`:
-required status contexts must remain unambiguous. During bootstrap, older
-path-filtered workflows remain diagnostic-only; remove them in a later PR only
-after the ruleset requires this fan-in context.
+required status contexts must remain unambiguous. Older path-filtered workflows
+remain diagnostic-only; remove them in a later PR only after confirming the PR Gate
+continues to cover each validation domain.
 
 ## Bot update policy
 


### PR DESCRIPTION
## Change and risk

- [x] I identified the affected domain(s): docs, agent guidance, and PR process.
- [x] I ran the applicable local validation commands and recorded them below.
- [x] User approval is pending; this PR intentionally has auto-merge disabled.
- [ ] The user explicitly approved head SHA `<sha>` for merge; I then enabled native auto-merge with `gh pr merge --auto --squash`.

This PR codifies the user-to-agent authorization boundary: agents may validate, commit to feature branches, and open PRs, but they must not enable auto-merge or otherwise merge until the user explicitly approves the reported current PR head SHA. Any new commit invalidates that approval.

No R1/R2 operation, GitHub ruleset change, cluster mutation, deployment, or secret change is included.

## Critical / destructive changes

- [x] Not applicable.
- [ ] This is R1: I described the affected critical resource or ownership/access-plane field below.
- [ ] This is R2: I followed `docs/runbooks/destructive-gitops-change.md`, including the required two-PR intent/consumption sequence and backup/rollback evidence.

## Validation evidence

- `git diff --check`
- Local Markdown link validation for updated documentation
- Targeted YAML lint of `.github/pull_request_template.md`
- Checksum-verified Actionlint v1.7.9 over all workflows
- Searched updated agent/CI guidance for contradictory `git push origin main` instructions

## Rollback

Revert through a normal PR. Do not bypass the ruleset or push directly to `main`.
