### PR TITLE
fix(paperclip): restore health probes

### DIFF
--- a/apps/kyrion/ai/paperclip-values.yaml
+++ b/apps/kyrion/ai/paperclip-values.yaml
@@ -5,6 +5,20 @@ vars:
   PAPERCLIP_PUBLIC_URL: https://paperclip.${ts_net}
   PAPERCLIP_AUTH_PUBLIC_BASE_URL: https://paperclip.${ts_net}
   PAPERCLIP_ALLOWED_HOSTNAMES: paperclip.${ts_net}
+# Paperclip rejects kubelet's default Pod-IP Host header in authenticated mode.
+# Override only the host header so OneChart retains the shared probe path and timing.
+container:
+  readinessProbe:
+    httpGet:
+      httpHeaders:
+        - name: Host
+          value: paperclip.${ts_net}
+  livenessProbe:
+    httpGet:
+      httpHeaders:
+        - name: Host
+          value: paperclip.${ts_net}
+
 ingress:
   # The Tailscale Ingress controller expands this short name in the tailnet.
   host: paperclip


### PR DESCRIPTION
## Change and risk

- [x] I identified the affected domain(s): GitOps.
- [x] I ran the applicable local validation commands and recorded them below.
- [x] User approval is pending; this PR intentionally has auto-merge disabled.
- [ ] The user explicitly approved head SHA `<sha>` for merge; I then enabled native auto-merge with `gh pr merge --auto --squash`.

The Paperclip HelmRelease failed because authenticated-mode health probes received the kubelet's default Pod-IP `Host` header, which Paperclip rejected with HTTP 403. The overlay now supplies the configured Tailscale hostname as the HTTP probe `Host` header. This preserves the existing `/api/health` endpoint, probe timing, persistence, database release, and ingress configuration.

## Critical / destructive changes

- [x] Not applicable.
- [ ] This is R1: I described the affected critical resource or ownership/access-plane field below.
- [ ] This is R2: I followed `docs/runbooks/destructive-gitops-change.md`, including the required two-PR intent/consumption sequence and backup/rollback evidence.

## Validation evidence

- Confirmed the live failure: Paperclip started successfully and connected to PostgreSQL, but kubelet readiness/liveness requests received HTTP 403. Direct in-pod requests succeeded only with the configured hostname in the `Host` header.
- `kustomize build apps/kyrion/ai`
- `flux build kustomization apps --path ./apps/kyrion --kustomization-file clusters/kyrion/apps.yaml --dry-run`
- `helm lint charts/onechart`
- Rendered Paperclip from the overlay and HelmRelease values; asserted both probes retain `/api/health` on port `3100` and send the configured `Host` header.
- `kubeconform -strict -summary` on the rendered Paperclip workload: 5 valid resources.
- `bash scripts/ci/render_kustomize_targets.sh ...` and `bash scripts/ci/build_flux_kustomizations.sh ...`
- `yamllint -c .yamllint.yaml clusters infrastructure apps monitoring functions` (repository has existing encrypted-value line-length warnings only)
- `python3 scripts/ci/check_changed_secrets.py ... --skip-fetch`
- Trusted-base `critical_change_guard.py`: 0 findings.
- `git diff --check`

The repository-wide kubeconform advisory reports pre-existing schema incompatibilities for unrelated SealedSecrets and the Headlamp HelmRelease; no Paperclip resource was invalid, and the rendered Paperclip workload passed strict schema validation.

## Rollback

If this change causes a regression, revert the subsequent squash commit on `main`; it changes only Paperclip probe headers and does not mutate persistent data, database state, or credentials.
