### PR TITLE
fix(paperclip): watch generated helm values

### DIFF
--- a/apps/kyrion/ai/kustomization.yaml
+++ b/apps/kyrion/ai/kustomization.yaml
@@ -27,3 +27,5 @@ configMapGenerator:
       - values.yaml=paperclip-values.yaml
     options:
       disableNameSuffixHash: true
+      labels:
+        reconcile.fluxcd.io/watch: Enabled


### PR DESCRIPTION
## Change and risk

- [x] I identified the affected domain: GitOps.
- [x] I ran the applicable local validation commands and recorded them below.
- [x] User approval is pending; this PR intentionally has auto-merge disabled.
- [ ] The user explicitly approved the current head SHA `79fe3d8385b4897e5ec5a550b7b4e39ec90c8b52` for merge; native squash auto-merge remains disabled unless and until that approval is given.

This narrowly scoped repair adds the standard Flux watch label only to the generated `paperclip-helm-values` ConfigMap. The HelmRelease already consumes that ConfigMap through `valuesFrom`; the label lets helm-controller observe the values change without waiting for the 12-hour interval.

## Critical / destructive changes

- [x] Not applicable. This change does not alter a critical resource, ownership/access plane, persistent data, deployment configuration, database, Secret, or unrelated ConfigMap generator.
- [ ] This is R1.
- [ ] This is R2.

## Validation evidence

- `kustomize build apps/kyrion/ai`
- `flux build kustomization apps --path clusters/kyrion`
- Rendered-manifest assertion: `paperclip-helm-values` retains its no-name-hash behavior, has `reconcile.fluxcd.io/watch: Enabled`, and contains both configured probe Host headers.
- Helm render assertion: both probes retain `/api/health` on port `3100` and their configured Host headers.
- `yamllint apps/kyrion/ai/kustomization.yaml`
- `git diff --check`
- Trusted-base changed-Secret guard and critical GitOps guard (no critical or destructive changes detected).
- `python3 -m unittest tests.ci.test_pr_gate_helpers tests.ci.test_critical_change_guard` (28 tests passed).

## Rollback

Revert the subsequent squash commit. This only removes the ConfigMap watch label; it does not mutate persistent data or require a backup/restore operation.
