### PR TITLE
feat(ai): harden OneChart probes and Paperclip

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -311,7 +311,7 @@ jobs:
           quiet: true
           skip_results_upload: true
           output_format: json
-          output_file_path: quality-ratchet/base-checkov.json,
+          output_file_path: quality-ratchet/base-checkov.json
           config_file: base/.github/checkov.yaml
           soft_fail: true
 
@@ -323,7 +323,7 @@ jobs:
           quiet: true
           skip_results_upload: true
           output_format: json
-          output_file_path: quality-ratchet/head-checkov.json,
+          output_file_path: quality-ratchet/head-checkov.json
           config_file: base/.github/checkov.yaml
           soft_fail: true
 

--- a/apps/base/paperclip/README.md
+++ b/apps/base/paperclip/README.md
@@ -21,3 +21,15 @@ They are still backup-required: issue #90 tracks the required off-cluster backup
 restore contract. Before a destructive storage change or chart-major upgrade, verify
 a recorded restore drill and use a Git revert/new PR for rollback rather than deleting
 PVCs.
+
+The Paperclip Deployment is explicitly single-writer (`strategy: Recreate`) and
+runs with a non-root uid/gid, dropped Linux capabilities, `RuntimeDefault` seccomp,
+and no automatically mounted ServiceAccount token. In authenticated/private mode,
+the `ai` overlay preserves the canonical `Host` header on readiness and liveness
+requests because Paperclip rejects kubelet's Pod-IP host header.
+
+OneChart only rolls a pod automatically when its generated ConfigMap or image changes;
+SealedSecret-backed environment changes need an explicit controlled rollout. When
+rotating `paperclip-secrets`, update a non-sensitive `podAnnotations` revision in the
+Helm values in the same PR, verify a single successful replacement Pod, and retain the
+previous SealedSecret manifest as the Git rollback point.

--- a/apps/base/paperclip/paperclip-release.yaml
+++ b/apps/base/paperclip/paperclip-release.yaml
@@ -33,10 +33,16 @@ spec:
       valuesKey: values.yaml
   values:
     replicas: 1
+    # Paperclip uses a single RWO data PVC; never allow two pod writers.
+    strategy: Recreate
     containerPort: 3100
     svcPort: 3100
     podSecurityContext:
       fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    podSpec:
+      automountServiceAccountToken: false
     # The upstream entrypoint supports direct non-root execution as uid/gid 1000.
     securityContext:
       allowPrivilegeEscalation: false

--- a/charts/onechart/Chart.yaml
+++ b/charts/onechart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.74.0
+version: 0.75.0
 
 dependencies:
   - name: common

--- a/charts/onechart/charts/common/templates/_podSpec.yaml
+++ b/charts/onechart/charts/common/templates/_podSpec.yaml
@@ -13,7 +13,8 @@ serviceAccountName: {{ .Values.serviceAccount }}
 initContainers:
   {{- range .Values.initContainers }}  
   - name:  {{ .name }}
-    image: "{{ .image }}:{{ .tag }}"
+    {{- $image := printf "%s:%s" .image .tag }}
+    image: "{{ $image }}{{ with .digest }}@{{ . }}{{ end }}"
     imagePullPolicy: {{ .imagePullPolicy | default "IfNotPresent" }}
     {{- include "common.envFromRef.tpl" $ | nindent 4 }}
     {{- if .command }}
@@ -36,7 +37,16 @@ initContainers:
   {{- end }}      
 containers:
   {{- $containerTpl := include "common.container.tpl" . | fromYaml }}
-  {{- $container := mergeOverwrite $containerTpl .Values.container }}
+  {{- $containerOverrides := deepCopy .Values.container }}
+  {{- range $probeName := list "readinessProbe" "livenessProbe" }}
+  {{- if hasKey $containerOverrides $probeName }}
+  {{- $probeOverride := get $containerOverrides $probeName }}
+  {{- if and (kindIs "map" $probeOverride) (or (hasKey $probeOverride "exec") (hasKey $probeOverride "tcpSocket")) }}
+  {{- $_ := unset (get $containerTpl $probeName) "httpGet" }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- $container := mergeOverwrite $containerTpl $containerOverrides }}
   - {{ toYaml $container | nindent 4 }}
     {{- include "common.envFromRef.tpl" . | nindent 4 }}
     {{- include "common.volumeMountsRef.tpl" . | nindent 4 }}

--- a/charts/onechart/tests/deployment_initcontainers_test.yaml
+++ b/charts/onechart/tests/deployment_initcontainers_test.yaml
@@ -20,6 +20,20 @@ tests:
         equal:
           path: spec.template.spec.initContainers[0].image
           value: "nginx:1.2.2"
+  - it: Should append an immutable digest to the init container image
+    set:
+      initContainers:
+        - name: pod1
+          image: nginx
+          tag: 1.2.2
+          digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    asserts:
+      - template: deployment.yaml
+        documentIndex: 0
+        equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "nginx:1.2.2@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
   - it: Should set command  
     set:
       initContainers:

--- a/charts/onechart/tests/deployment_liveness_probe_test.yaml
+++ b/charts/onechart/tests/deployment_liveness_probe_test.yaml
@@ -49,3 +49,27 @@ tests:
             successThreshold: 1
             timeoutSeconds: 3
             failureThreshold: 3
+  - it: Should replace generated HTTP liveness with a TCP probe
+    set:
+      livenessProbe:
+        enabled: true
+      container:
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          failureThreshold: 6
+    asserts:
+      - template: deployment.yaml
+        documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+            failureThreshold: 6

--- a/charts/onechart/tests/deployment_probe_test.yaml
+++ b/charts/onechart/tests/deployment_probe_test.yaml
@@ -49,3 +49,79 @@ tests:
             successThreshold: 1
             timeoutSeconds: 3
             failureThreshold: 3
+  - it: Should merge HTTPS headers and a startup probe into readiness
+    set:
+      probe:
+        enabled: true
+      container:
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            httpHeaders:
+              - name: Host
+                value: app.example.test
+        startupProbe:
+          httpGet:
+            path: /startup
+            port: 80
+            scheme: HTTPS
+          periodSeconds: 5
+          failureThreshold: 24
+    asserts:
+      - template: deployment.yaml
+        documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: "/"
+              port: 80
+              scheme: HTTPS
+              httpHeaders:
+                - name: Host
+                  value: app.example.test
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+            failureThreshold: 3
+      - template: deployment.yaml
+        documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /startup
+              port: 80
+              scheme: HTTPS
+            periodSeconds: 5
+            failureThreshold: 24
+  - it: Should replace generated HTTP readiness with an exec probe
+    set:
+      probe:
+        enabled: true
+      container:
+        readinessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - test -f /tmp/ready
+          periodSeconds: 5
+          failureThreshold: 6
+    asserts:
+      - template: deployment.yaml
+        documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - test -f /tmp/ready
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+            failureThreshold: 6

--- a/charts/onechart/values.schema.json
+++ b/charts/onechart/values.schema.json
@@ -125,6 +125,17 @@
                 "type": "string",
                 "title": "Tag"
               },
+              "digest": {
+                "type": "string",
+                "title": "Digest",
+                "description": "Optional SHA-256 OCI image digest appended to the init-container image tag.",
+                "default": "",
+                "pattern": "^(|sha256:[A-Fa-f0-9]{64})$",
+                "examples": [
+                  "",
+                  "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                ]
+              },
               "imagePullPolicy": {
                 "type": "string",
                 "title": "Command",
@@ -170,6 +181,18 @@
       "maximum": 16,
       "examples": [
         1
+      ]
+    },
+    "strategy": {
+      "$id": "#/properties/strategy",
+      "type": "string",
+      "title": "Deployment strategy",
+      "description": "Optional Deployment strategy type. Leave empty to retain OneChart's automatic Recreate strategy for a single replica with a volume.",
+      "default": "",
+      "examples": [
+        "",
+        "Recreate",
+        "RollingUpdate"
       ]
     },
     "podDisruptionBudgetEnabled": {
@@ -714,6 +737,22 @@
           }
         }
       }
+    },
+    "container": {
+      "$id": "#/properties/container",
+      "type": "object",
+      "title": "Main container overlay",
+      "description": "Merged into the generated main container. Use complete Kubernetes probe objects here for exec, HTTPS, custom HTTP headers, or startup probes.",
+      "default": {},
+      "additionalProperties": true
+    },
+    "podSpec": {
+      "$id": "#/properties/podSpec",
+      "type": "object",
+      "title": "PodSpec overlay",
+      "description": "Merged into the generated PodSpec for Kubernetes fields not exposed directly by OneChart.",
+      "default": {},
+      "additionalProperties": true
     },
     "secretName": {
       "$id": "#/properties/secretName",

--- a/charts/onechart/values.yaml
+++ b/charts/onechart/values.yaml
@@ -18,7 +18,18 @@ image:
 # vars:
 #   MY_VAR: "value"
 
+# Optional init containers accept image, tag, and an optional immutable digest.
+# initContainers:
+#   - name: initialize-data
+#     image: example/init
+#     tag: v1.2.3
+#     digest: sha256:<64 hexadecimal characters>
+
 replicas: 1
+
+# Empty preserves the automatic Recreate strategy for a single replica with a volume.
+# Set to Recreate or RollingUpdate to override that default.
+strategy: ""
 
 nameOverride: ""
 fullnameOverride: ""
@@ -80,5 +91,11 @@ nodePortEnabled: false
 monitor:
   enabled: false
 
+# Merged into the generated main container. Use it for complete Kubernetes probe
+# objects (for example exec, HTTPS, custom HTTP headers, or startupProbe) when the
+# HTTP readiness/liveness shorthand above is not sufficient.
 container: {}
+
+# Merged into the generated PodSpec for Kubernetes fields not exposed directly by
+# OneChart, such as automountServiceAccountToken.
 podSpec: {}


### PR DESCRIPTION
## What changed

- Added digest-pinned init-container image support to OneChart.
- Made full `container` probe overrides safe for `exec` and `tcpSocket` handlers while preserving HTTP/HTTPS header overlays and startup probes.
- Documented the generic escape hatches, added schema coverage, and bumped OneChart to `0.75.0`.
- Hardened Paperclip with explicit `Recreate`, `RuntimeDefault` seccomp, and no automatic ServiceAccount token mount; PVCs, Secrets, database topology, image policy, and hostname-aware probes are unchanged.
- Repaired PR Gate Checkov report paths: trailing commas caused the Checkov action to write reports at filenames that the quality-ratchet reader never consumed.

## Validation

- `jq empty charts/onechart/values.schema.json`
- `helm lint charts/onechart`
- `helm unittest charts/onechart` — 104 tests passed
- `ct lint --config ct.yaml --all`
- `yamllint` on all changed YAML files
- `kustomize build apps/base/paperclip`
- `kustomize build apps/kyrion/ai`
- `kustomize build apps/kyrion`
- `flux build kustomization apps --path clusters/kyrion`
- `helm template` for the Paperclip OneChart values and raw-probe scenarios
- `python3 -m unittest tests.ci.test_pr_gate_helpers tests.ci.test_critical_change_guard` — 31 tests passed
- `python3 -m py_compile scripts/ci/*.py tests/ci/*.py && bash -n scripts/ci/*.sh && shellcheck scripts/ci/*.sh`
- `git diff --check`

## Risks and rollout

- The Paperclip Deployment rolls once after reconciliation because the Pod template gains explicit security/strategy fields. Its RWO PVC and Bitnami PostgreSQL release are not changed.
- This workspace has no Kubernetes context, so post-merge Flux and workload readiness must be observed from the approved administrative path before a follow-up PR.

## Merge authorization

- [ ] User approval pending for current head `c245796f06bf774e7ed31d1b32f835c6f541b05d`; auto-merge remains disabled.
