### PR TITLE
fix(ci): isolate normalized Checkov reports

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -330,8 +330,8 @@ jobs:
       - name: Normalize Checkov JSON reports for trusted comparison
         run: |
           python3 base/scripts/ci/normalize_checkov_reports.py \
-            --report "$GITHUB_WORKSPACE/quality-ratchet/base-checkov.json" \
-            --report "$GITHUB_WORKSPACE/quality-ratchet/head-checkov.json"
+            --report "$GITHUB_WORKSPACE/quality-ratchet/base-checkov.json" "$RUNNER_TEMP/quality-ratchet/base-checkov.json" \
+            --report "$GITHUB_WORKSPACE/quality-ratchet/head-checkov.json" "$RUNNER_TEMP/quality-ratchet/head-checkov.json"
 
       - name: Compare Kubernetes security findings without increasing debt
         env:
@@ -339,7 +339,7 @@ jobs:
           HEAD_SHA: ${{ needs.detect.outputs.head_sha }}
         run: |
           set -euo pipefail
-          workspace="$GITHUB_WORKSPACE/quality-ratchet"
+          workspace="$RUNNER_TEMP/quality-ratchet"
           python3 base/scripts/ci/quality_ratchet.py \
             --tool checkov \
             --base-report "$workspace/base-checkov.json" \
@@ -357,7 +357,7 @@ jobs:
           name: quality-ratchet-gitops-${{ github.event.pull_request.number }}
           path: |
             quality-ratchet/quality-kubeconform.json
-            quality-ratchet/quality-checkov.json
+            ${{ runner.temp }}/quality-ratchet/quality-checkov.json
           if-no-files-found: warn
           retention-days: 7
 

--- a/scripts/ci/normalize_checkov_reports.py
+++ b/scripts/ci/normalize_checkov_reports.py
@@ -4,7 +4,11 @@
 Checkov 3.3 omits ``results.parsing_errors`` when there are no parsing errors.
 The quality-ratchet parser intentionally requires an explicit list so malformed
 scanner output fails closed. This helper accepts only that absent-and-equivalent
-shape and writes the explicit empty list expected by the parser.
+shape and writes the explicit empty list to a separate trusted output path.
+
+Checkov's container action may make its workspace report files root-owned. The
+helper therefore never mutates its input report; callers provide a writable
+output path, normally under ``RUNNER_TEMP``.
 """
 
 from __future__ import annotations
@@ -25,8 +29,10 @@ def parse_args() -> argparse.Namespace:
         "--report",
         type=Path,
         action="append",
+        nargs=2,
+        metavar=("INPUT", "OUTPUT"),
         required=True,
-        help="Checkov JSON report to normalize; may be specified multiple times.",
+        help="Read INPUT Checkov JSON and write a normalized copy to OUTPUT; may be specified multiple times.",
     )
     return parser.parse_args()
 
@@ -44,33 +50,38 @@ def load_report(path: Path) -> dict[str, Any]:
     return payload
 
 
-def normalize_report(path: Path) -> None:
-    payload = load_report(path)
+def normalize_report(input_path: Path, output_path: Path) -> None:
+    """Validate INPUT and write its normalized representation to OUTPUT."""
+    payload = load_report(input_path)
     results = payload.get("results")
     if not isinstance(results, dict):
-        raise CheckovReportError(f"Checkov report has no results object: {path}")
+        raise CheckovReportError(f"Checkov report has no results object: {input_path}")
 
     failed_checks = results.get("failed_checks")
     if not isinstance(failed_checks, list):
-        raise CheckovReportError(f"Checkov report has invalid failed_checks list: {path}")
+        raise CheckovReportError(f"Checkov report has invalid failed_checks list: {input_path}")
 
     if "parsing_errors" not in results:
         results["parsing_errors"] = []
     else:
         parsing_errors = results["parsing_errors"]
         if not isinstance(parsing_errors, list):
-            raise CheckovReportError(f"Checkov report has invalid parsing_errors list: {path}")
+            raise CheckovReportError(f"Checkov report has invalid parsing_errors list: {input_path}")
         if parsing_errors:
-            raise CheckovReportError(f"Checkov report contains parsing errors: {path}")
+            raise CheckovReportError(f"Checkov report contains parsing errors: {input_path}")
 
-    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    except OSError as error:
+        raise CheckovReportError(f"Cannot write normalized Checkov report: {output_path}: {error}") from error
 
 
 def main() -> int:
     args = parse_args()
     try:
-        for report in args.report:
-            normalize_report(report)
+        for input_path, output_path in args.report:
+            normalize_report(input_path, output_path)
     except CheckovReportError as error:
         raise SystemExit(str(error)) from error
     return 0

--- a/tests/ci/test_normalize_checkov_reports.py
+++ b/tests/ci/test_normalize_checkov_reports.py
@@ -36,50 +36,57 @@ class NormalizeCheckovReportsTest(unittest.TestCase):
         self.tempdir.cleanup()
 
     def report(self, name: str, payload: object) -> Path:
-        path = self.root / name
+        path = self.root / "input" / name
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(payload), encoding="utf-8")
         return path
 
-    def test_missing_parsing_errors_is_normalized_to_empty_list(self) -> None:
+    def output(self, name: str) -> Path:
+        return self.root / "runner-temp" / "normalized" / name
+
+    def test_missing_parsing_errors_is_normalized_to_separate_output(self) -> None:
         report = self.report("checkov.json", {"results": {"failed_checks": []}})
+        output = self.output("checkov.json")
 
-        NORMALIZER.normalize_report(report)
+        NORMALIZER.normalize_report(report, output)
 
+        self.assertEqual(json.loads(report.read_text(encoding="utf-8")), {"results": {"failed_checks": []}})
         self.assertEqual(
-            json.loads(report.read_text(encoding="utf-8")),
+            json.loads(output.read_text(encoding="utf-8")),
             {"results": {"failed_checks": [], "parsing_errors": []}},
         )
 
     def test_existing_empty_parsing_errors_is_preserved(self) -> None:
         report = self.report("checkov.json", {"results": {"failed_checks": [], "parsing_errors": []}})
+        output = self.output("checkov.json")
 
-        NORMALIZER.normalize_report(report)
+        NORMALIZER.normalize_report(report, output)
 
-        self.assertEqual(json.loads(report.read_text(encoding="utf-8"))["results"]["parsing_errors"], [])
+        self.assertEqual(json.loads(output.read_text(encoding="utf-8"))["results"]["parsing_errors"], [])
 
     def test_missing_results_object_fails_closed(self) -> None:
         report = self.report("checkov.json", {})
 
         with self.assertRaisesRegex(NORMALIZER.CheckovReportError, "no results object"):
-            NORMALIZER.normalize_report(report)
+            NORMALIZER.normalize_report(report, self.output("checkov.json"))
 
     def test_missing_failed_checks_list_fails_closed(self) -> None:
         report = self.report("checkov.json", {"results": {}})
 
         with self.assertRaisesRegex(NORMALIZER.CheckovReportError, "invalid failed_checks"):
-            NORMALIZER.normalize_report(report)
+            NORMALIZER.normalize_report(report, self.output("checkov.json"))
 
     def test_non_list_parsing_errors_fails_closed(self) -> None:
         report = self.report("checkov.json", {"results": {"failed_checks": [], "parsing_errors": {}}})
 
         with self.assertRaisesRegex(NORMALIZER.CheckovReportError, "invalid parsing_errors"):
-            NORMALIZER.normalize_report(report)
+            NORMALIZER.normalize_report(report, self.output("checkov.json"))
 
     def test_non_empty_parsing_errors_fails_closed(self) -> None:
         report = self.report("checkov.json", {"results": {"failed_checks": [], "parsing_errors": ["invalid manifest"]}})
 
         with self.assertRaisesRegex(NORMALIZER.CheckovReportError, "contains parsing errors"):
-            NORMALIZER.normalize_report(report)
+            NORMALIZER.normalize_report(report, self.output("checkov.json"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Incident repair

PR #109 exposed a second self-repair defect in the Checkov report normalizer merged by #108. `bridgecrewio/checkov-action` leaves `quality-ratchet/*.json` root-owned, so the trusted helper failed while attempting to rewrite its input report:

```text
PermissionError: [Errno 13] Permission denied: .../quality-ratchet/base-checkov.json
```

This PR keeps the parser strict but changes the trusted helper to read Checkov reports from the action-owned workspace and write normalized copies, plus the derived Checkov quality report, under writable `RUNNER_TEMP`. It does not evaluate or execute PR-provided code.

## Scope

- CI policy/helper/test files only; no application manifests or runtime configuration.
- The earlier application-only post-recovery PR #109 remains unchanged and will be re-run only after this repair is on `main`.

## Validation

- `python3 -m unittest tests.ci.test_normalize_checkov_reports tests.ci.test_pr_gate_helpers tests.ci.test_critical_change_guard tests.ci.test_quality_ratchet tests.ci.test_quality_ratchet_shell tests.ci.test_split_rendered_manifests` — 63 tests passed
- `python3 -m py_compile scripts/ci/*.py tests/ci/*.py`
- `bash -n scripts/ci/*.sh`
- `shellcheck scripts/ci/*.sh`
- checksum-verified `actionlint` 1.7.9 on `.github/workflows/pr-gate.yml`
- `yamllint .github/workflows/pr-gate.yml`
- read-only Checkov-input CLI smoke test, verifying the source report stays unmodified and the normalized copy is written under a separate runner-temp-style path
- `git diff --check`

## Break-glass requirement

Because `pull_request_target` executes the normalizer from trusted `main`, its required GitOps check is expected to repeat the permission failure until this fix reaches `main`. Follow `docs/runbooks/github-break-glass.md`: retain all protections except temporarily removing only `PR Gate / required`, native-squash-auto-merge this repair after explicit approval of this head SHA, immediately restore the required context, then re-run #109 to prove the repaired gate.
