### PR TITLE
chore(monitoring): reduce Flux rule lint debt

### DIFF
--- a/monitoring/configs/flux-safety-rules.yaml
+++ b/monitoring/configs/flux-safety-rules.yaml
@@ -11,7 +11,13 @@ spec:
       rules:
         - alert: FluxBootstrapKustomizationNotReady
           expr: >-
-            gotk_resource_info{customresource_group="kustomize.toolkit.fluxcd.io",customresource_kind="Kustomization",exported_namespace="flux-system",name=~"apps|infra-controllers|infra-configs|monitoring-controllers|monitoring-configs",ready!="True"} == 1
+            gotk_resource_info{
+              customresource_group="kustomize.toolkit.fluxcd.io",
+              customresource_kind="Kustomization",
+              exported_namespace="flux-system",
+              name=~"apps|infra-controllers|infra-configs|monitoring-controllers|monitoring-configs",
+              ready!="True"
+            } == 1
           for: 10m
           labels:
             severity: critical
@@ -23,7 +29,12 @@ spec:
               mutate the cluster directly to clear the alert.
         - alert: FluxCriticalHelmReleaseNotReady
           expr: >-
-            gotk_resource_info{customresource_group="helm.toolkit.fluxcd.io",customresource_kind="HelmRelease",name=~"flux-operator|flux-instance|sealed-secrets|tailscale-operator|tsidp",ready!="True"} == 1
+            gotk_resource_info{
+              customresource_group="helm.toolkit.fluxcd.io",
+              customresource_kind="HelmRelease",
+              name=~"flux-operator|flux-instance|sealed-secrets|tailscale-operator|tsidp",
+              ready!="True"
+            } == 1
           for: 10m
           labels:
             severity: critical
@@ -35,7 +46,11 @@ spec:
               diagnose through Git and Flux status before any destructive action.
         - alert: TailscaleAccessPlaneResourceNotReady
           expr: >-
-            gotk_resource_info{customresource_group="tailscale.com",customresource_kind=~"Connector|DNSConfig|ProxyClass|ProxyGroup",ready!="True"} == 1
+            gotk_resource_info{
+              customresource_group="tailscale.com",
+              customresource_kind=~"Connector|DNSConfig|ProxyClass|ProxyGroup",
+              ready!="True"
+            } == 1
           for: 10m
           labels:
             severity: critical
@@ -47,7 +62,11 @@ spec:
               administrative connectivity is affected.
         - alert: TailscaleCriticalResourceInventoryReduced
           expr: >-
-            count(gotk_resource_info{customresource_group="tailscale.com",customresource_kind=~"Connector|DNSConfig|ProxyClass|ProxyGroup",name=~"connector|default|ts-dns|tsidp-egress"}) < 4
+            count(gotk_resource_info{
+              customresource_group="tailscale.com",
+              customresource_kind=~"Connector|DNSConfig|ProxyClass|ProxyGroup",
+              name=~"connector|default|ts-dns|tsidp-egress"
+            }) < 4
           for: 10m
           labels:
             severity: critical


### PR DESCRIPTION
## What changed

- Wrapped four existing PromQL expressions in the Flux safety `PrometheusRule` for readable YAML.
- The rendered rule fields are unchanged except for whitespace outside quoted PromQL literals; no alert name, selector, threshold, duration, label, annotation, or CI policy changed.

## Quality-debt reduction

- Reduces yamllint's current `line-length` baseline by **4** findings:
  - `FluxBootstrapKustomizationNotReady`
  - `FluxCriticalHelmReleaseNotReady`
  - `TailscaleAccessPlaneResourceNotReady`
  - `TailscaleCriticalResourceInventoryReduced`
- Local trusted-base ratchet result: `PASS WITH DEBT REDUCTION` — 93 base findings, 89 head findings, 4 removed, 0 added.

## Validation

- `yamllint monitoring/configs/flux-safety-rules.yaml`
- `kustomize build monitoring/configs`
- `flux build kustomization monitoring-configs --path clusters/kyrion`
- Parsed the base and rendered `PrometheusRule`; all non-expression fields match and the four expressions differ only by whitespace outside quoted literals.
- Trusted-base `run_quality_ratchet.sh --tool yamllint` result: `PASS WITH DEBT REDUCTION`, 0 added / 4 removed.
- `git diff --check`

## Merge authorization

- [ ] User approval pending for current head `481659739aef957cdc362abfc511be7de8b3e853`; auto-merge remains disabled.
