### PR TITLE
chore(onechart): wrap chart description

### DIFF
--- a/charts/onechart/Chart.yaml
+++ b/charts/onechart/Chart.yaml
@@ -1,6 +1,8 @@
 apiVersion: v2
 name: onechart
-description: One chart to rule them all. A generic Helm chart for your application deployments. Because no-one can remember the Kubernetes yaml syntax.
+description: >-
+  One chart to rule them all. A generic Helm chart for your application
+  deployments. Because no-one can remember the Kubernetes yaml syntax.
 
 # A chart can be either an 'application' or a 'library' chart.
 #


### PR DESCRIPTION
## What changed

Wraps the OneChart `Chart.yaml` prose `description` as a YAML folded scalar.

## Why

This removes one repository-wide yamllint line-length warning while preserving the exact parsed Helm chart description and all other chart metadata. The PR is deliberately limited to chart metadata formatting; no templates, values, dependencies, releases, or CI policy change.

## Validation

- Parsed base and proposed `Chart.yaml` files and asserted the resolved `description` plus every other metadata field are unchanged
- `yamllint -c .yamllint.yaml charts/onechart/Chart.yaml`
- repository-wide yamllint finding count: **91 → 90**
- `helm lint charts/onechart`
- `helm unittest charts/onechart` — 38 suites / 104 tests passed
- `kustomize build apps/kyrion/arkham`
- `flux build kustomization apps --path ./apps/kyrion --kustomization-file clusters/kyrion/apps.yaml --dry-run`
- `git diff --check`

`ct lint` is unavailable in this devcontainer, so the PR Gate chart validator remains the required verification for that command.

## Safety

- No workload or rendered chart-template changes.
- No secrets, Flux resource changes, or CI/policy changes.
- Auto-merge remains disabled pending green CI and explicit approval of the current head SHA.
