### PR TITLE
chore(cron-job): wrap chart description

### DIFF
--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -1,6 +1,8 @@
 apiVersion: v2
 name: cron-job
-description: One chart to rule them all. A generic Helm chart for your application deployments. Because no-one can remember the Kubernetes yaml syntax.
+description: >-
+  One chart to rule them all. A generic Helm chart for your application
+  deployments. Because no-one can remember the Kubernetes yaml syntax.
 
 # A chart can be either an 'application' or a 'library' chart.
 #


### PR DESCRIPTION
## What changed

Wraps the CronJob chart `Chart.yaml` prose `description` as a YAML folded scalar.

## Why

This removes one repository-wide yamllint line-length warning while preserving the exact parsed Helm chart description and all other chart metadata. The change is metadata-only: no templates, values, dependencies, releases, Flux resources, secrets, or CI policy are changed.

## Validation

- Parsed base and proposed `Chart.yaml` files and asserted the resolved `description` plus all other metadata fields are identical
- `yamllint -c .yamllint.yaml charts/cron-job/Chart.yaml`
- repository-wide yamllint finding count: **91 → 90**
- `helm lint charts/cron-job`
- `helm unittest charts/cron-job` — 11 suites / 18 tests passed
- `kustomize build apps/kyrion/arkham`
- `flux build kustomization apps --path ./apps/kyrion --kustomization-file clusters/kyrion/apps.yaml --dry-run`
- `git diff --check`

`ct lint` is not available in this devcontainer; the chart-specific PR Gate validator will run it remotely.

## Safety

Auto-merge remains disabled pending green CI and explicit approval of the current head SHA.
