### PR TITLE
fix(flux-operator-mcp): restore ingress policy

### DIFF
--- a/infrastructure/controllers/flux-operator-mcp/release.yaml
+++ b/infrastructure/controllers/flux-operator-mcp/release.yaml
@@ -32,10 +32,13 @@ spec:
     # The chart's generated binding is cluster-admin; use the reviewed role above.
     rbac:
       create: false
-    # Temporarily disable the chart-generated policy while diagnosing whether
-    # Mux's MCP-manager runtime is blocked before it can list the server tools.
     networkPolicy:
-      create: false
+      create: true
+      ingress:
+        # Allow approved in-cluster MCP clients to reach the internal HTTP endpoint.
+        namespaces:
+          - coder
+          - ai
     ingress:
       enabled: false
     httpRoute:


### PR DESCRIPTION
## What and why

Restore the chart-generated least-privilege ingress `NetworkPolicy` for `flux-operator-mcp`.

PR #115 temporarily removed this policy to diagnose Mux MCP tool discovery. Flux reconciled the removal and a newly initialized Mux workspace still failed with `Connection closed`, so the NetworkPolicy was disproven as the cause. Restoring it removes unnecessary service exposure while preserving the original approved in-cluster client allowlist (`coder`, `ai`).

## Validation

- `kustomize build infrastructure/controllers/flux-operator-mcp`
- `yamllint infrastructure/controllers/flux-operator-mcp`
- `git diff --check`
- Verified `infra-controllers` reconciled PR #115 and deleted the `flux-operator-mcp` NetworkPolicy before retesting Mux; the new workspace still could not discover any Flux MCP tools.

## Merge approval

User explicitly approved squash auto-merge for this current change at head `166a277e65015ab97ee6d98a88f8fba4636eac0d`.