### PR TITLE
fix(sealed-secrets): remove cluster template timestamp

### DIFF
--- a/clusters/kyrion/sealed-secrets.yaml
+++ b/clusters/kyrion/sealed-secrets.yaml
@@ -16,7 +16,6 @@ spec:
     ts_net: AgA+TUgNyO2iIqOOwJtR8hbKxRZcoVTOWRfCQtx6oXgG5KRhXGrczVSVFY9lMbs0sD6hpaKzGLILtino8INeGkiofLA7uvggFJ+egIEAnhqQXI7GlicZ2EYrudv4hYRDK+hAYxOc0PHcOEukvOPgFRXb1dWjaS8Yvj2cFHFVPU7YmtJ4kKY31izVK4Mp+mnkgL3LmzYIlMSf9AOI0ojkLQGIl58k8LC/FXzQffTyoJNsh8/aTkseh75MhX+6HQEX44jyWK/Xel3cUPHCrlY55aFZOrzWffjNrX5q0A6qFiAtcGkD+KfAPr7uxWdpq3WwFYyTWthXnEVRmP0d5CvBIzT48LU6IlQYOca9I7YFETxSVdICVAFS0H3QPjGnZZSEq25YOuxQm2ntzNOV3PBxR2LBXrKhaaUFLWwioxeUqGks0fkldmBjH6trHj73C9v/YsYOmq5JxSdF0QF49jDo5q6pYkkz35W/LJ3Lp/ZTc7xoF4haH2AyiHBcZnaq+nKzxLTuYN7+axMYBRQWV1kFq0BFLzFxczXGS9C3FzFVKfoOAjz09EQWYB39XczNkA7gODPpprPHobSVtBXqsGUmUXg7UiAPoRjF+HnRQm6UDMugxfgocI/wKQSMZDiQCWwEQRfugriPoGu36Jaay/IBb9HUAvf1JicO3sPZ5/mqj/GrRo7sXZRZoAIMxTLH2+9HL08SgbDd7Fczs0HrC8P2L4TDKyQsGO6IbQ==
   template:
     metadata:
-      creationTimestamp: null
       name: cluster-secret-vars
       namespace: flux-system
     type: Opaque


### PR DESCRIPTION
## What changed

Removes only the invalid nested `spec.template.metadata.creationTimestamp: null` field from the cluster-level `SealedSecret/cluster-secret-vars` template.

## Why

The pinned SealedSecret CRD schema rejects this template-only timestamp. Removing it reduces inherited kubeconform debt while leaving all encrypted data, the top-level metadata timestamp, Secret identity, namespace, type, annotations, and Flux composition unchanged.

## Validation

- Parsed base/proposed YAML and asserted the only semantic difference is removal of the nested template timestamp
- `yamllint -c .yamllint.yaml clusters/kyrion/sealed-secrets.yaml` — only pre-existing ciphertext line-length warnings
- Direct strict kubeconform validation against the PR Gate's pinned CRD catalog: valid
- Rendered `cluster-secret-vars` from `kustomize build clusters/kyrion` and validated it against the same schema: valid
- Full local yamllint ratchet: **PASS WITH EXISTING DEBT** (`85 → 85`, 0 added)
- Full local kubeconform ratchet: **PASS WITH DEBT REDUCTION** (`21 → 20`, 1 removed, 0 added)
- `git diff --check`

## Safety

- No plaintext or encrypted secret value is changed.
- No CI/policy, Flux dependency, or root Kustomization composition change.
- The top-level `metadata.creationTimestamp` remains intentionally untouched; the rejected field is specifically nested under `spec.template.metadata`.
- The user authorized native squash auto-merge for subsequent reduction PRs; it will be enabled only after green required checks on this reported head.
