### PR TITLE
feat(backup): add reusable VolSync platform

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ For AI coding agents, `AGENTS.md` at the repository root is the portable entry p
   - **[Adding Applications](runbooks/add-application.md)** - Complete workflow for deploying apps
   - **[Adding Infrastructure Components](runbooks/add-infrastructure-component.md)** - Platform controller/config workflow
   - **[Resource Optimization](runbooks/resource-optimization.md)** - Optimizing cluster resources
+  - **[Backup and Restore](runbooks/backup-and-restore.md)** - Encrypted PVC backups and restore drills
   - **[Flux Web UI with tsidp OIDC](runbooks/flux-web-ui.md)** - Private-domain authenticated Flux dashboard and read-only RBAC
   - **[Flux Operator Migration](runbooks/flux-operator-migration.md)** - Staged migration from the generated Flux bootstrap
   - **[Gitless ResourceSet Image Automation](runbooks/resourceset-image-automation.md)** - Gitless workload image updates and rollback controls

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -17,6 +17,7 @@ This directory contains step-by-step procedures for routine operational tasks. E
 - **[Gitless ResourceSet Image Automation](resourceset-image-automation.md)** - Gitless workload image updates, safety gates, and rollback pins
 
 ### Cluster Operations
+- **[Backup and Restore](backup-and-restore.md)** - Reusable encrypted PVC backup contract and restore drills
 - **[Flux Web UI with tsidp OIDC](flux-web-ui.md)** - Private-domain Flux dashboard, OIDC client sealing, read-only RBAC, and rollback
 - **[Migrating Flux to Flux Operator](flux-operator-migration.md)** - Staged, zero-downtime migration and optional internal MCP rollout
 

--- a/docs/runbooks/backup-and-restore.md
+++ b/docs/runbooks/backup-and-restore.md
@@ -1,0 +1,172 @@
+# Backup and restore
+
+This runbook defines the reusable backup and restore contract for persistent
+applications. VolSync provides the Kubernetes API and Restic provides
+client-side encryption, retention, repository integrity, and object-storage
+support. OpenClaw is the first workload adopting the contract; each additional
+PVC uses the same resource shapes and operational gates.
+
+## Recovery contract
+
+The repository-wide baseline is:
+
+| Objective | Baseline |
+|---|---|
+| Backup schedule | Every 6 hours |
+| RPO | 24 hours |
+| RTO for one application PVC | 2 hours |
+| Retention | 4 hourly, 7 daily, 5 weekly, 12 monthly snapshots |
+| Repository | One encrypted Restic repository path per PVC |
+| Restore verification | At least quarterly and before a destructive migration |
+
+An application may declare stricter objectives in its own documentation. A
+less strict objective requires an explicit risk decision; it must not be
+introduced by silently weakening the shared monitoring rules.
+
+## Inventory and consistency tier
+
+Before onboarding a workload, record all persistent state and choose one tier:
+
+- **filesystem**: files can be copied while the application is running;
+- **application-consistent**: the application exposes a supported flush,
+  checkpoint, or backup hook;
+- **stopped**: the workload must be stopped before the final backup.
+
+`copyMethod: Direct` is the portable baseline for `local-path` PVCs because it
+does not require CSI snapshots. It reads the mounted volume directly and does
+not make a live database transactionally consistent. For SQLite, database
+servers, or similar state, use an application hook or a stopped final backup
+for destructive operations. Validate restored databases with their native
+integrity tooling; file presence alone is not sufficient.
+
+## Secret contract
+
+Create one namespace-scoped Secret per protected PVC. The Secret name is
+referenced by `spec.restic.repository` and contains the Restic variables needed
+by the selected backend:
+
+- `RESTIC_REPOSITORY` with a unique, non-sensitive repository path;
+- `RESTIC_PASSWORD` with a unique encryption password;
+- backend credentials such as `AWS_ACCESS_KEY_ID` and
+  `AWS_SECRET_ACCESS_KEY` for an S3-compatible endpoint;
+- optional backend settings required by Restic, such as region or endpoint.
+
+Store only a SealedSecret in Git. Never reuse a repository path between PVCs,
+print secret values in logs, or publish bucket names, private endpoints,
+snapshot IDs, object keys, credentials, or encryption material. Keep a private
+recovery copy of the repository password and backend credentials outside the
+cluster; a SealedSecret alone is not a disaster-recovery copy because it is
+tied to the cluster sealing key.
+
+Use least-privilege backend credentials restricted to the workload repository
+prefix. Rotate and revoke them after a suspected disclosure and after temporary
+migration access is no longer required.
+
+## Onboard a PVC
+
+Keep the `ReplicationSource` with the application owner, not with the VolSync
+controller. The reusable shape is:
+
+```yaml
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: <application>-backup
+  namespace: <application-namespace>
+spec:
+  sourcePVC: <pvc-name>
+  trigger:
+    schedule: "0 */6 * * *"
+  restic:
+    copyMethod: Direct
+    repository: <application>-restic
+    pruneIntervalDays: 7
+    retain:
+      hourly: 4
+      daily: 7
+      weekly: 5
+      monthly: 12
+    moverResources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 1
+        memory: 1Gi
+```
+
+Confirm that the PVC, Secret, and `ReplicationSource` share a namespace. Render
+the application base and cluster overlay before merging. After reconciliation,
+wait for `status.lastSyncTime`, inspect `status.latestMoverStatus.result`, and
+verify that the three generic VolSync alerts remain inactive. Do not treat the
+resource being `Ready` as proof that recoverable data exists.
+
+## Perform a restore drill
+
+Never restore over the production PVC during a drill.
+
+1. Select a known successful snapshot privately and record only its timestamp
+   and redacted identifier in the evidence.
+2. Create a scratch PVC in an isolated drill namespace with enough capacity.
+3. Materialize the repository Secret in that namespace using a separately
+   sealed copy of the same private values.
+4. Create a temporary `ReplicationDestination` using `copyMethod: Direct`, the
+   scratch PVC as `destinationPVC`, and a unique manual trigger value.
+5. Wait until `status.lastManualSync` equals the trigger and the latest mover
+   result is `Successful`.
+6. Mount the restored PVC read-only in an offline validation Job. Disable
+   service exposure and egress unless the validation itself requires a reviewed
+   destination.
+7. Verify required files, ownership, permissions, symlinks, and application
+   invariants. Run native integrity checks for every restored database.
+8. Record elapsed restore time against the RTO and publish only redacted
+   evidence.
+9. Remove the validation Job, `ReplicationDestination`, scratch PVC, and
+   drill-only Secret through Git. Confirm their deletion before closing the
+   drill.
+
+The destination shape is:
+
+```yaml
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationDestination
+metadata:
+  name: <application>-restore-drill
+  namespace: <drill-namespace>
+spec:
+  trigger:
+    manual: <unique-trigger>
+  restic:
+    copyMethod: Direct
+    repository: <application>-restic
+    destinationPVC: <scratch-pvc>
+```
+
+## Destructive-operation gate
+
+Before deleting, replacing, migrating, or shrinking persistent storage, require
+all of the following:
+
+- a successful backup within the workload RPO;
+- backend confirmation that encrypted objects exist off-cluster;
+- a completed restore drill from the same repository and credential set;
+- application-level integrity checks on the restored data;
+- measured restore time within the RTO;
+- a rollback owner and an explicit approval tied to the current Git revision.
+
+If any item is missing, stop the destructive operation. A backup log without a
+restore drill is not sufficient evidence.
+
+## Evidence and incident response
+
+Public evidence may include UTC start/end times, duration, byte/file counts,
+high-level integrity results, RPO/RTO outcome, and redacted snapshot hashes. It
+must exclude credentials, repository passwords, bucket or endpoint identifiers,
+object keys, private domains, internal addresses, and restored application
+content.
+
+Alert response starts at the first failing control point: verify the
+`ReplicationSource` status, then the mover Job and events, Secret key names
+without values, PVC mount/scheduling, and finally backend reachability. Do not
+run `restic unlock` or mutate repository state until an active writer has been
+excluded and the action is approved.

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - arc
   - flux-operator
   - flux-operator-mcp
+  - volsync

--- a/infrastructure/controllers/volsync/README.md
+++ b/infrastructure/controllers/volsync/README.md
@@ -1,0 +1,14 @@
+# VolSync controller
+
+VolSync provides the shared PVC backup and restore API used by applications in
+this repository. Workload-specific `ReplicationSource` and
+`ReplicationDestination` resources remain with the owning application; this
+directory owns only the controller, CRDs, namespace, and metrics endpoint.
+
+The chart manages the `volsync.backube` CRDs. Flux uses `Create` during install
+and `CreateReplace` during upgrades so schema changes are reconciled with the
+controller release. Review CRD compatibility and the upstream release notes
+before changing the pinned chart version.
+
+See [Backup and restore](../../../docs/runbooks/backup-and-restore.md) for the
+repository contract and onboarding procedure.

--- a/infrastructure/controllers/volsync/kustomization.yaml
+++ b/infrastructure/controllers/volsync/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - release.yaml

--- a/infrastructure/controllers/volsync/namespace.yaml
+++ b/infrastructure/controllers/volsync/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: volsync-system

--- a/infrastructure/controllers/volsync/release.yaml
+++ b/infrastructure/controllers/volsync/release.yaml
@@ -1,0 +1,38 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: volsync
+  namespace: volsync-system
+spec:
+  interval: 1h
+  timeout: 10m
+  chart:
+    spec:
+      chart: volsync
+      version: "0.16.0"
+      sourceRef:
+        kind: HelmRepository
+        name: volsync
+        namespace: volsync-system
+  install:
+    crds: Create
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  values:
+    manageCRDs: true
+    metrics:
+      # The Service is cluster-internal; disabling controller-runtime RBAC auth
+      # lets the Prometheus Operator's generated ServiceMonitor scrape it.
+      disableAuth: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 1
+        memory: 1Gi

--- a/infrastructure/controllers/volsync/repository.yaml
+++ b/infrastructure/controllers/volsync/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: volsync
+  namespace: volsync-system
+spec:
+  interval: 24h
+  url: https://backube.github.io/helm-charts/

--- a/monitoring/configs/kustomization.yaml
+++ b/monitoring/configs/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - podmonitor.yaml
   - grafana-mcp-monitor.yaml
   - resourceset-image-automation-rules.yaml
+  - volsync-backup-rules.yaml
 
 configMapGenerator:
   - name: flux-grafana-dashboards

--- a/monitoring/configs/volsync-backup-rules.yaml
+++ b/monitoring/configs/volsync-backup-rules.yaml
@@ -1,0 +1,44 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: volsync-backups
+  labels:
+    app.kubernetes.io/name: volsync
+    app.kubernetes.io/component: monitoring
+spec:
+  groups:
+    - name: volsync-backups
+      rules:
+        - alert: VolSyncBackupNeverSucceeded
+          expr: |-
+            (time() - volsync_replication_source_created_time_seconds > 7200)
+              unless on (exported_namespace, name)
+            volsync_replication_source_last_sync_time_seconds
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: VolSync backup has never succeeded
+            description: >-
+              ReplicationSource {{ $labels.exported_namespace }}/{{ $labels.name }}
+              has no successful backup two hours after creation.
+        - alert: VolSyncBackupLatestMoverFailed
+          expr: volsync_replication_source_latest_mover_result{result="Failed"} == 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: Latest VolSync backup mover failed
+            description: >-
+              The latest mover for ReplicationSource
+              {{ $labels.exported_namespace }}/{{ $labels.name }} reported failure.
+        - alert: VolSyncBackupRPOBreached
+          expr: time() - volsync_replication_source_last_sync_time_seconds > 86400
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: VolSync backup exceeded the baseline RPO
+            description: >-
+              ReplicationSource {{ $labels.exported_namespace }}/{{ $labels.name }}
+              has no successful backup in the last 24 hours.

--- a/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml
+++ b/monitoring/controllers/kube-prometheus-stack/kube-state-metrics-config.yaml
@@ -34,6 +34,11 @@ kube-state-metrics:
           - resourcesets
           - resourcesetinputproviders
         verbs: ["list", "watch"]
+      - apiGroups:
+          - volsync.backube
+        resources:
+          - replicationsources
+        verbs: ["list", "watch"]
   customResourceState:
     enabled: true
     config:
@@ -58,6 +63,45 @@ kube-state-metrics:
                   suspended: [spec, suspend]
                   revision: [status, lastAppliedRevision]
                   source_name: [spec, sourceRef, name]
+          - groupVersionKind:
+              group: volsync.backube
+              version: v1alpha1
+              kind: ReplicationSource
+            metricNamePrefix: volsync
+            labelsFromPath:
+              exported_namespace: [metadata, namespace]
+              name: [metadata, name]
+            metrics:
+              - name: "replication_source_info"
+                help: "Information about a VolSync ReplicationSource."
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      paused: [spec, paused]
+                      source_pvc: [spec, sourcePVC]
+              - name: "replication_source_created_time_seconds"
+                help: "Unix creation time of a VolSync ReplicationSource."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [metadata, creationTimestamp]
+              - name: "replication_source_last_sync_time_seconds"
+                help: "Unix time of the last successful VolSync source synchronization."
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [status, lastSyncTime]
+              - name: "replication_source_latest_mover_result"
+                help: "Result reported by the latest VolSync source mover."
+                each:
+                  type: StateSet
+                  stateSet:
+                    labelName: result
+                    path: [status, latestMoverStatus, result]
+                    list:
+                      - Successful
+                      - Failed
           - groupVersionKind:
               group: helm.toolkit.fluxcd.io
               version: v2


### PR DESCRIPTION
## Summary

Introduce the shared backup/restore platform needed by #90 and by the OpenClaw backup in #121.

- install VolSync 0.16.0 as an infrastructure controller with chart-managed CRDs
- export generic ReplicationSource status through kube-state-metrics
- alert when a backup never succeeds, the latest mover fails, or the 24-hour baseline RPO is breached
- document the reusable encrypted Restic contract, consistency tiers, restore drills, evidence redaction, and destructive-operation gates

This is phase 1 only. It intentionally does not modify the OpenClaw Deployment, Service, Flux resources, PVC, or Secrets, and it does not claim that #121 is complete. After this controller is merged and reconciled, a separate gated change will add the OpenClaw ReplicationSource and real SealedSecret, followed by the restore drill.

## Validation

- `kubectl kustomize infrastructure/controllers`
- `kubectl kustomize infrastructure/controllers/volsync`
- `kubectl kustomize clusters/kyrion/infrastructure/controllers`
- `kubectl kustomize monitoring/controllers`
- `kubectl kustomize monitoring/configs`
- `flux build kustomization infra-controllers --path clusters/kyrion/infrastructure/controllers --kustomization-file clusters/kyrion/infrastructure.yaml --dry-run`
- `flux build kustomization monitoring-controllers --path monitoring/controllers --kustomization-file clusters/kyrion/monitoring.yaml --dry-run`
- `flux build kustomization monitoring-configs --path monitoring/configs --kustomization-file clusters/kyrion/monitoring.yaml --dry-run`
- `git diff --check`

## Operational notes

- VolSync uses `copyMethod: Direct` as the portable baseline for local-path PVCs; live database consistency still requires an application hook or a stopped final backup.
- Workload repository passwords and backend credentials remain out of Git and must be supplied as namespace-scoped SealedSecrets.
- No plaintext secret, private endpoint, bucket identifier, or internal topology was added.

Relates to #90.
Prerequisite for #121.