### PR TITLE
feat(ci): compare kubeconform schema policy

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -42,6 +42,7 @@ jobs:
       quality_inputs_changed: ${{ steps.changes.outputs.quality_inputs_changed }}
       yamllint_policy_changed: ${{ steps.changes.outputs.yamllint_policy_changed }}
       checkov_policy_changed: ${{ steps.changes.outputs.checkov_policy_changed }}
+      kubeconform_policy_changed: ${{ steps.changes.outputs.kubeconform_policy_changed }}
     steps:
       - name: Check out trusted base
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
@@ -303,6 +304,23 @@ jobs:
             --schema-location "https://raw.githubusercontent.com/datreeio/CRDs-catalog/${CRDS_CATALOG_COMMIT}/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" \
             --github-summary "$GITHUB_STEP_SUMMARY"
 
+      - name: Publish the effect of candidate kubeconform schema policy
+        if: needs.detect.outputs.kubeconform_policy_changed == 'true'
+        env:
+          BASE_SHA: ${{ needs.detect.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.detect.outputs.head_sha }}
+        run: |
+          bash base/scripts/ci/run_kubeconform_policy_effect.sh \
+            --rendered-root "$GITHUB_WORKSPACE/quality-ratchet/base-kubeconform-input" \
+            --base-schemas-root "$GITHUB_WORKSPACE/base/.github/schemas" \
+            --base-catalog-commit "${CRDS_CATALOG_COMMIT}" \
+            --candidate-workflow "$GITHUB_WORKSPACE/.github/workflows/pr-gate.yml" \
+            --candidate-schemas-root "$GITHUB_WORKSPACE/.github/schemas" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --report-dir "$RUNNER_TEMP/quality-policy" \
+            --github-summary "$GITHUB_STEP_SUMMARY"
+
       - name: Scan trusted base Kubernetes configuration for ratchet comparison
         uses: bridgecrewio/checkov-action@9b70310bcd306d11740313070b940167d6b23085 # v12.3115.0
         with:
@@ -357,6 +375,7 @@ jobs:
           name: quality-ratchet-gitops-${{ github.event.pull_request.number }}
           path: |
             quality-ratchet/quality-kubeconform.json
+            ${{ runner.temp }}/quality-policy/quality-kubeconform.json
             ${{ runner.temp }}/quality-ratchet/quality-checkov.json
           if-no-files-found: warn
           retention-days: 7

--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -115,6 +115,16 @@ reference for both sides of a comparison. Updating a schema source, tool version
 local schema is itself a quality-policy-only change and must publish its effect on the
 current trusted base before it can govern manifest changes.
 
+
+Kubeconform accepts ordered schema locations. The trusted scan consults Kubernetes'
+default schemas first, then repository-local schemas when present, and finally the
+commit-pinned Datree catalog. A PR that changes the PR Gate catalog pin or local
+schema files is scanned a second time against the same trusted rendered base: the
+base policy uses trusted locations while the candidate policy is parsed from the
+proposed workflow and schema files only as inert data. The comparison publishes any
+resulting finding reduction or regression before that policy can govern later
+manifest PRs; proposed workflow or helper code is never executed by this step.
+
 PRs may continue to merge while this work proceeds. A rebase or new commit simply
 reruns comparison against the newer trusted base, so a finding fixed by another PR
 cannot be reintroduced as inherited debt.

--- a/scripts/ci/detect_pr_gate_domains.py
+++ b/scripts/ci/detect_pr_gate_domains.py
@@ -35,6 +35,13 @@ QUALITY_POLICY_FILES = {
     ".yamllint.yaml",
 }
 QUALITY_POLICY_PREFIXES = (".github/schemas/", "scripts/ci/")
+KUBECONFORM_POLICY_FILES = {".github/workflows/pr-gate.yml"}
+KUBECONFORM_POLICY_PREFIXES = (
+    ".github/schemas/",
+    "scripts/ci/run_quality_ratchet.sh",
+    "scripts/ci/run_kubeconform_policy_effect.sh",
+    "scripts/ci/resolve_kubeconform_schema_locations.py",
+)
 QUALITY_INPUT_PREFIXES = ("clusters/", "infrastructure/", "apps/", "monitoring/", "functions/")
 
 
@@ -79,6 +86,10 @@ def classify_quality_paths(paths: Iterable[str]) -> dict[str, bool]:
         "yamllint_policy_changed": ".yamllint.yaml" in path_list,
         "checkov_policy_changed": any(
             path in {".checkov.yaml", ".checkov.yml", ".github/checkov.yaml"} for path in path_list
+        ),
+        "kubeconform_policy_changed": any(
+            path in KUBECONFORM_POLICY_FILES or path.startswith(KUBECONFORM_POLICY_PREFIXES)
+            for path in path_list
         ),
     }
 

--- a/scripts/ci/resolve_kubeconform_schema_locations.py
+++ b/scripts/ci/resolve_kubeconform_schema_locations.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Resolve candidate kubeconform schema locations from inert policy data."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError as error:  # pragma: no cover - exercised by CI dependency setup
+    raise SystemExit(f"PyYAML is required by resolve_kubeconform_schema_locations.py: {error}")
+
+
+CATALOG_COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+SCHEMA_TEMPLATE = "{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workflow", type=Path, required=True, help="Inert proposed pr-gate workflow YAML")
+    parser.add_argument(
+        "--schemas-root",
+        type=Path,
+        required=True,
+        help="Inert proposed local-schema directory, if present",
+    )
+    parser.add_argument("--output", type=Path, required=True, help="Output file with one schema location per line")
+    return parser.parse_args()
+
+
+def catalog_commit(workflow: Path) -> str:
+    try:
+        document = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as error:
+        raise ValueError(f"cannot parse candidate workflow {workflow}: {error}") from error
+    if not isinstance(document, dict):
+        raise ValueError("candidate workflow must be a YAML mapping")
+    environment = document.get("env")
+    if not isinstance(environment, dict):
+        raise ValueError("candidate workflow is missing top-level env mapping")
+    commit = environment.get("CRDS_CATALOG_COMMIT")
+    if not isinstance(commit, str) or not CATALOG_COMMIT_PATTERN.fullmatch(commit):
+        raise ValueError("candidate CRDS_CATALOG_COMMIT must be exactly a 40-character lowercase SHA")
+    return commit
+
+
+def schema_locations(workflow: Path, schemas_root: Path) -> list[str]:
+    locations: list[str] = []
+    if schemas_root.exists():
+        if not schemas_root.is_dir():
+            raise ValueError(f"candidate schemas root is not a directory: {schemas_root}")
+        locations.append(str(schemas_root / SCHEMA_TEMPLATE))
+    commit = catalog_commit(workflow)
+    locations.append(
+        "https://raw.githubusercontent.com/datreeio/CRDs-catalog/"
+        f"{commit}/{SCHEMA_TEMPLATE}"
+    )
+    return locations
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        locations = schema_locations(args.workflow, args.schemas_root)
+    except ValueError as error:
+        print(f"Unable to resolve candidate kubeconform schema locations: {error}", file=sys.stderr)
+        return 1
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(locations) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_kubeconform_policy_effect.sh
+++ b/scripts/ci/run_kubeconform_policy_effect.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Compare trusted rendered input under base and proposed kubeconform schema policy.
+# The proposed workflow and schemas are parsed/scanned only as inert data.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  run_kubeconform_policy_effect.sh --rendered-root DIRECTORY \
+    --base-schemas-root DIRECTORY --base-catalog-commit SHA \
+    --candidate-workflow FILE --candidate-schemas-root DIRECTORY \
+    --base-sha SHA --head-sha SHA --report-dir DIRECTORY \
+    [--github-summary FILE]
+EOF
+}
+
+rendered_root=""
+base_schemas_root=""
+base_catalog_commit=""
+candidate_workflow=""
+candidate_schemas_root=""
+base_sha=""
+head_sha=""
+report_dir=""
+github_summary=""
+
+while (($#)); do
+  case "$1" in
+    --rendered-root)
+      rendered_root="$2"
+      shift 2
+      ;;
+    --base-schemas-root)
+      base_schemas_root="$2"
+      shift 2
+      ;;
+    --base-catalog-commit)
+      base_catalog_commit="$2"
+      shift 2
+      ;;
+    --candidate-workflow)
+      candidate_workflow="$2"
+      shift 2
+      ;;
+    --candidate-schemas-root)
+      candidate_schemas_root="$2"
+      shift 2
+      ;;
+    --base-sha)
+      base_sha="$2"
+      shift 2
+      ;;
+    --head-sha)
+      head_sha="$2"
+      shift 2
+      ;;
+    --report-dir)
+      report_dir="$2"
+      shift 2
+      ;;
+    --github-summary)
+      github_summary="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+for required in \
+  rendered_root base_schemas_root base_catalog_commit candidate_workflow \
+  candidate_schemas_root base_sha head_sha report_dir; do
+  test -n "${!required}" || {
+    echo "Missing required option --${required//_/-}" >&2
+    usage >&2
+    exit 2
+  }
+done
+
+if ! [[ "$base_catalog_commit" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "--base-catalog-commit must be exactly a 40-character lowercase SHA." >&2
+  exit 2
+fi
+
+test -d "$rendered_root"
+test -f "$candidate_workflow"
+if [ -e "$base_schemas_root" ]; then
+  test -d "$base_schemas_root"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+schema_template='{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+base_catalog="https://raw.githubusercontent.com/datreeio/CRDs-catalog/${base_catalog_commit}/${schema_template}"
+candidate_locations="$report_dir/candidate-schema-locations.txt"
+mkdir -p "$report_dir"
+
+python3 "$script_dir/resolve_kubeconform_schema_locations.py" \
+  --workflow "$candidate_workflow" \
+  --schemas-root "$candidate_schemas_root" \
+  --output "$candidate_locations"
+
+base_arguments=(--base-schema-location "$base_catalog")
+if [ -d "$base_schemas_root" ]; then
+  base_arguments=(
+    --base-schema-location "$base_schemas_root/$schema_template"
+    "${base_arguments[@]}"
+  )
+fi
+
+head_arguments=()
+while IFS= read -r location; do
+  test -n "$location" || {
+    echo "Candidate kubeconform schema locations must not be empty." >&2
+    exit 1
+  }
+  head_arguments+=(--head-schema-location "$location")
+done < "$candidate_locations"
+((${#head_arguments[@]})) || {
+  echo "Candidate kubeconform schema policy produced no schema locations." >&2
+  exit 1
+}
+
+arguments=(
+  --tool kubeconform
+  --base-root "$rendered_root"
+  --head-root "$rendered_root"
+  --base-sha "$base_sha"
+  --head-sha "$head_sha"
+  --report-dir "$report_dir"
+  "${base_arguments[@]}"
+  "${head_arguments[@]}"
+)
+if [ -n "$github_summary" ]; then
+  arguments+=(--github-summary "$github_summary")
+fi
+bash "$script_dir/run_quality_ratchet.sh" "${arguments[@]}"

--- a/scripts/ci/run_quality_ratchet.sh
+++ b/scripts/ci/run_quality_ratchet.sh
@@ -10,10 +10,14 @@ Usage:
     --base-root DIRECTORY --head-root DIRECTORY \
     --base-sha SHA --head-sha SHA --report-dir DIRECTORY \
     [--base-config FILE] [--head-config FILE] [--head-scan-root DIRECTORY] \
-    [--github-summary FILE] [--schema-location URL] [--reject-removed]
+    [--github-summary FILE] [--schema-location LOCATION]... \
+    [--base-schema-location LOCATION]... [--head-schema-location LOCATION]... \
+    [--reject-removed]
 
-Both scans use this helper and the supplied trusted configuration paths. A policy
-comparison may scan trusted base content with a proposed configuration as inert data.
+Both scans use this helper and the supplied trusted configuration paths. Repeated
+--schema-location options apply to both kubeconform scans in the given order. A
+policy comparison may instead supply distinct base/head schema locations while
+scanning trusted base content with proposed policy data as inert input.
 EOF
 }
 
@@ -24,7 +28,9 @@ base_sha=""
 head_sha=""
 report_dir=""
 github_summary=""
-schema_location=""
+schema_locations=()
+base_schema_locations=()
+head_schema_locations=()
 base_config=""
 head_config=""
 head_scan_root=""
@@ -77,7 +83,15 @@ while (($#)); do
       shift 2
       ;;
     --schema-location)
-      schema_location="$2"
+      schema_locations+=("$2")
+      shift 2
+      ;;
+    --base-schema-location)
+      base_schema_locations+=("$2")
+      shift 2
+      ;;
+    --head-schema-location)
+      head_schema_locations+=("$2")
       shift 2
       ;;
     --help|-h)
@@ -150,13 +164,28 @@ scan_yamllint() {
 scan_kubeconform() {
   local rendered="$1"
   local report="$2"
+  shift 2
+  local -a locations=("$@")
+  local -a command=(
+    kubeconform
+    -strict
+    -output json
+    -summary
+    -schema-location default
+  )
+  local location
   local exit_code
 
+  for location in "${locations[@]}"; do
+    test -n "$location" || {
+      echo "kubeconform schema locations must not be empty." >&2
+      exit 2
+    }
+    command+=(-schema-location "$location")
+  done
+
   set +e
-  kubeconform -strict -output json -summary \
-    -schema-location default \
-    -schema-location "$schema_location" \
-    "$rendered" >"$report" 2>"$report.stderr"
+  "${command[@]}" "$rendered" >"$report" 2>"$report.stderr"
   exit_code=$?
   set -e
 
@@ -193,12 +222,20 @@ case "$tool" in
     root_options=(--base-root "$base_root" --head-root "$head_scan_root")
     ;;
   kubeconform)
-    test -n "$schema_location" || {
-      echo "--schema-location is required for kubeconform." >&2
+    if ((${#schema_locations[@]})); then
+      if ((${#base_schema_locations[@]} || ${#head_schema_locations[@]})); then
+        echo "Use either --schema-location or both --base-schema-location and --head-schema-location." >&2
+        exit 2
+      fi
+      base_schema_locations=("${schema_locations[@]}")
+      head_schema_locations=("${schema_locations[@]}")
+    fi
+    if ((${#base_schema_locations[@]} == 0 || ${#head_schema_locations[@]} == 0)); then
+      echo "kubeconform requires --schema-location or both base/head schema locations." >&2
       exit 2
-    }
-    base_exit="$(scan_kubeconform "$base_root" "$report_dir/base-kubeconform.json")"
-    head_exit="$(scan_kubeconform "$head_root" "$report_dir/head-kubeconform.json")"
+    fi
+    base_exit="$(scan_kubeconform "$base_root" "$report_dir/base-kubeconform.json" "${base_schema_locations[@]}")"
+    head_exit="$(scan_kubeconform "$head_root" "$report_dir/head-kubeconform.json" "${head_schema_locations[@]}")"
     base_report="$report_dir/base-kubeconform.json"
     head_report="$report_dir/head-kubeconform.json"
     output_report="$report_dir/quality-kubeconform.json"

--- a/tests/ci/test_pr_gate_helpers.py
+++ b/tests/ci/test_pr_gate_helpers.py
@@ -27,6 +27,7 @@ def load_module(filename: str):
 
 DOMAINS = load_module("detect_pr_gate_domains.py")
 SECRETS = load_module("check_changed_secrets.py")
+SCHEMA_LOCATIONS = load_module("resolve_kubeconform_schema_locations.py")
 
 
 class DomainDetectionTest(unittest.TestCase):
@@ -59,6 +60,7 @@ class DomainDetectionTest(unittest.TestCase):
                 "quality_inputs_changed": True,
                 "yamllint_policy_changed": False,
                 "checkov_policy_changed": False,
+                "kubeconform_policy_changed": False,
             },
         )
 
@@ -70,6 +72,7 @@ class DomainDetectionTest(unittest.TestCase):
                 "quality_inputs_changed": False,
                 "yamllint_policy_changed": False,
                 "checkov_policy_changed": False,
+                "kubeconform_policy_changed": False,
             },
         )
 
@@ -86,8 +89,51 @@ class DomainDetectionTest(unittest.TestCase):
                 "quality_inputs_changed": False,
                 "yamllint_policy_changed": True,
                 "checkov_policy_changed": True,
+                "kubeconform_policy_changed": False,
             },
         )
+
+
+    def test_kubeconform_policy_paths_are_detected(self) -> None:
+        self.assertEqual(
+            DOMAINS.classify_quality_paths(
+                [
+                    ".github/schemas/apiextensions.k8s.io/customresourcedefinition_v1.json",
+                    ".github/workflows/pr-gate.yml",
+                ]
+            )["kubeconform_policy_changed"],
+            True,
+        )
+
+
+class KubeconformSchemaLocationsTest(unittest.TestCase):
+    def test_candidate_policy_uses_local_schema_before_catalog(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            workflow = root / "pr-gate.yml"
+            schemas = root / "schemas"
+            schemas.mkdir()
+            workflow.write_text(
+                "env:\n  CRDS_CATALOG_COMMIT: 59abc9f9403c92e3d8f8873e250ca10dcd5b2c0d\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                SCHEMA_LOCATIONS.schema_locations(workflow, schemas),
+                [
+                    str(schemas / SCHEMA_LOCATIONS.SCHEMA_TEMPLATE),
+                    "https://raw.githubusercontent.com/datreeio/CRDs-catalog/"
+                    "59abc9f9403c92e3d8f8873e250ca10dcd5b2c0d/"
+                    "{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+                ],
+            )
+
+    def test_candidate_policy_rejects_an_unpinned_catalog_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            workflow = root / "pr-gate.yml"
+            workflow.write_text("env:\n  CRDS_CATALOG_COMMIT: main\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "40-character lowercase SHA"):
+                SCHEMA_LOCATIONS.schema_locations(workflow, root / "missing")
 
 
 class ChangedSecretsTest(unittest.TestCase):

--- a/tests/ci/test_quality_ratchet_shell.py
+++ b/tests/ci/test_quality_ratchet_shell.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -41,6 +42,59 @@ class QualityRatchetShellTest(unittest.TestCase):
             encoding="utf-8",
         )
         (root / "apps/example.yaml").write_text("value: inherited-long-value\n", encoding="utf-8")
+
+    def install_fake_kubeconform(self) -> Path:
+        executable = self.root / "bin" / "kubeconform"
+        executable.parent.mkdir(exist_ok=True)
+        executable.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "printf '%s\\n' \"$@\" >> \"${KUBECONFORM_ARGS:?}\"\n"
+            "printf '%s\\n' --CALL-- >> \"${KUBECONFORM_ARGS:?}\"\n"
+            "printf '%s\\n' '{\"resources\": []}'\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+        return executable.parent
+
+    def run_kubeconform_helper(self, *schema_arguments: str) -> tuple[subprocess.CompletedProcess[str], list[list[str]]]:
+        binary_dir = self.install_fake_kubeconform()
+        arguments_log = self.root / "kubeconform-arguments.txt"
+        environment = os.environ | {
+            "PATH": f"{binary_dir}{os.pathsep}{os.environ['PATH']}",
+            "KUBECONFORM_ARGS": str(arguments_log),
+        }
+        result = subprocess.run(
+            [
+                "bash",
+                str(SCRIPT),
+                "--tool",
+                "kubeconform",
+                "--base-root",
+                str(self.base),
+                "--head-root",
+                str(self.head),
+                "--base-sha",
+                "a" * 40,
+                "--head-sha",
+                "b" * 40,
+                "--report-dir",
+                str(self.reports),
+                *schema_arguments,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=environment,
+        )
+        calls = []
+        if arguments_log.exists():
+            calls = [
+                call.splitlines()
+                for call in arguments_log.read_text(encoding="utf-8").split("--CALL--\n")
+                if call
+            ]
+        return result, calls
 
     def run_helper(self) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
@@ -126,6 +180,84 @@ class QualityRatchetShellTest(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 2)
         self.assertIn("Usage", result.stderr)
+
+    def test_kubeconform_passes_repeated_schema_locations_in_order(self) -> None:
+        result, calls = self.run_kubeconform_helper(
+            "--schema-location",
+            "local/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+            "--schema-location",
+            "catalog/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        expected = [
+            "-strict",
+            "-output",
+            "json",
+            "-summary",
+            "-schema-location",
+            "default",
+            "-schema-location",
+            "local/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+            "-schema-location",
+            "catalog/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+        ]
+        self.assertEqual(calls, [expected + [str(self.base)], expected + [str(self.head)]])
+
+    def test_kubeconform_policy_comparison_uses_distinct_schema_sets(self) -> None:
+        result, calls = self.run_kubeconform_helper(
+            "--base-schema-location",
+            "base-local/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+            "--base-schema-location",
+            "base-catalog/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+            "--head-schema-location",
+            "head-local/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+            "--head-schema-location",
+            "head-catalog/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        base_expected = [
+            "-strict",
+            "-output",
+            "json",
+            "-summary",
+            "-schema-location",
+            "default",
+            "-schema-location",
+            "base-local/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+            "-schema-location",
+            "base-catalog/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+            str(self.base),
+        ]
+        head_expected = [
+            "-strict",
+            "-output",
+            "json",
+            "-summary",
+            "-schema-location",
+            "default",
+            "-schema-location",
+            "head-local/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+            "-schema-location",
+            "head-catalog/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json",
+            str(self.head),
+        ]
+        self.assertEqual(calls, [base_expected, head_expected])
+
+    def test_kubeconform_rejects_missing_or_ambiguous_schema_locations(self) -> None:
+        missing, _ = self.run_kubeconform_helper()
+        self.assertEqual(missing.returncode, 2)
+        self.assertIn("requires --schema-location", missing.stderr)
+
+        ambiguous, _ = self.run_kubeconform_helper(
+            "--schema-location",
+            "catalog",
+            "--base-schema-location",
+            "base-catalog",
+            "--head-schema-location",
+            "head-catalog",
+        )
+        self.assertEqual(ambiguous.returncode, 2)
+        self.assertIn("either --schema-location", ambiguous.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Added ordered and base/head-specific kubeconform schema-location support to the trusted quality-ratchet helper.
- Added a trusted-base policy-effect comparison that parses a candidate PR Gate catalog pin and candidate local schemas strictly as inert data, then scans the same trusted rendered corpus under old/new schema locations.
- Added safe catalog-SHA validation, policy-path detection, focused regression tests, and documentation of the trust boundary.

## Why

This prepares separate policy-only follow-ups to refresh the Flux HelmRelease schema catalog and add a strict native CustomResourceDefinition schema, without allowing proposed workflow/helper code to execute in `pull_request_target`.

## Validation

- `python3 -m unittest tests.ci.test_pr_gate_helpers tests.ci.test_critical_change_guard tests.ci.test_quality_ratchet tests.ci.test_quality_ratchet_shell tests.ci.test_split_rendered_manifests`
- `python3 -m py_compile scripts/ci/*.py tests/ci/*.py`
- `bash -n scripts/ci/*.sh`
- `shellcheck scripts/ci/*.sh`
- checksum-verified `actionlint 1.7.9 .github/workflows/pr-gate.yml`
- `yamllint .github/workflows/pr-gate.yml docs/ci/pr-validation.md`
- `git diff --check`

No manifests, functions, runtime resources, secrets, or cluster state are changed.
