### PR TITLE
feat(error-pages): stage dedicated namespace overlay

### DIFF
--- a/apps/kyrion/error-pages/kustomization.yaml
+++ b/apps/kyrion/error-pages/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: error-pages
+
+resources:
+  - namespace.yaml
+  - ../../base/error-pages
+
+configMapGenerator:
+  - name: error-pages-helm-values
+    literals: []
+    options:
+      disableNameSuffixHash: true

--- a/apps/kyrion/error-pages/namespace.yaml
+++ b/apps/kyrion/error-pages/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: error-pages


### PR DESCRIPTION
## What changed

- Added a namespace-scoped, renderable `apps/kyrion/error-pages` overlay with `Namespace/error-pages` and the existing namespace-agnostic error-pages base.
- Left the new overlay out of the aggregate `apps/kyrion/kustomization.yaml`, so Flux does not yet reconcile it and the existing default backend remains unchanged.

## Why

This is the safe preparation phase for moving error-pages out of Kubernetes `default` without creating a second active default-backend Ingress. A later policy-reference PR can move CI targets to this existing overlay; the subsequent cutover PR is allowed to incur brief homelab downtime.

## Validation

- `kustomize build apps/kyrion/error-pages`
- `kustomize build apps/kyrion`
- `flux build kustomization apps --path clusters/kyrion`
- `yamllint apps/kyrion/error-pages`
- Python assertion of the rendered seven-resource identity set and namespaces
- `git diff --check`

No existing Flux aggregate, runtime resource, ingress, middleware, Secret, PVC, or cluster state changes in this PR.
