### PR TITLE
chore(ci): render dedicated error-pages overlay

### DIFF
--- a/.github/workflows/pr-validate-flux.yml
+++ b/.github/workflows/pr-validate-flux.yml
@@ -55,7 +55,7 @@ jobs:
           - apps/kyrion/airflow
           - apps/kyrion/arkham
           - apps/kyrion/coder
-          - apps/kyrion/default
+          - apps/kyrion/error-pages
           - apps/kyrion/fission
           - apps/kyrion/n8n
           - apps/kyrion/raiplaysoundrss
@@ -200,9 +200,9 @@ jobs:
             rendered/
 
       # checkov: real pre-existing findings exist against this repo's rendered
-      # manifests (14 unique after dedup), concentrated in the
-      # apps/kyrion/ai/copilot-api Deployment's pod-hardening posture plus a
-      # namespace-naming nit on the apps/kyrion/default overlay. None are
+      # manifests (13 unique after dedup), concentrated in the
+      # apps/kyrion/ai/copilot-api Deployment's pod-hardening posture plus two
+      # default-namespace findings on the legacy error-pages overlay. None are
       # functional bugs. This step is intentionally non-blocking (`soft_fail`)
       # pending remediation, tracked in issue #66. Once that issue is resolved,
       # `soft_fail` should be removed to make this step blocking again.

--- a/scripts/ci/render_kustomize_targets.sh
+++ b/scripts/ci/render_kustomize_targets.sh
@@ -44,7 +44,7 @@ targets=(
   apps/kyrion/airflow
   apps/kyrion/arkham
   apps/kyrion/coder
-  apps/kyrion/default
+  apps/kyrion/error-pages
   apps/kyrion/fission
   apps/kyrion/n8n
   apps/kyrion/raiplaysoundrss


### PR DESCRIPTION
## What changed

- Updated the legacy Flux validation workflow and trusted PR Gate render-target helper to render `apps/kyrion/error-pages` instead of `apps/kyrion/default`.
- Corrected the legacy workflow comment to the verified 13-finding Checkov baseline and described the two remaining legacy default-namespace findings accurately.

## Why

PR #124 staged a dormant, renderable dedicated error-pages overlay. This policy/reference-only PR makes CI validate that new overlay before the later runtime cutover removes the old default overlay. It does not change a Flux aggregate, runtime resource, Checkov policy, or baseline.

## Validation

- `bash scripts/ci/render_kustomize_targets.sh --root . --output <temp> --temp-root <temp>` and assertion that only `apps-kyrion-error-pages.yaml` is emitted
- `kustomize build apps/kyrion/error-pages`
- `flux build kustomization apps --path clusters/kyrion`
- checksum-verified `actionlint 1.7.9 .github/workflows/pr-validate-flux.yml`
- `yamllint .github/workflows/pr-validate-flux.yml`
- `bash -n` and `shellcheck scripts/ci/render_kustomize_targets.sh`
- `git diff --check`

No manifests, secrets, PVCs, deployments, ingress routes, or cluster state are changed.
