### PR TITLE
feat(ci): protect Copilot API decommissioning

### DIFF
--- a/.github/critical-resources.yaml
+++ b/.github/critical-resources.yaml
@@ -63,6 +63,7 @@ render_targets:
   tailscale: infrastructure/configs/tailscale
   networking: infrastructure/configs/networking
   arkham: apps/kyrion/arkham
+  copilot_api: apps/kyrion/ai
 # Single-document resources outside a local Kustomization target are parsed as
 # inert YAML. This avoids traversing the controller catalog's legacy remote CRD
 # base while still protecting the credentials that recover the access plane.
@@ -334,6 +335,53 @@ resources:
       - spec
     r2_fields:
       - metadata.annotations
+  # Copilot API is being decommissioned as a single R2 operation. Protect every
+  # rendered resource so a future removal cannot omit the PVC, access route, or
+  # credential object from the intent/rollback review.
+  - id: storage/copilot-api-pvc
+    target: copilot_api
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    namespace: ai
+    name: copilot-api-data
+    r2_fields:
+      - spec.accessModes
+      - spec.resources.requests.storage
+      - spec.storageClassName
+      - spec.volumeName
+  - id: workload/copilot-api-deployment
+    target: copilot_api
+    apiVersion: apps/v1
+    kind: Deployment
+    namespace: ai
+    name: copilot-api
+    r2_fields:
+      - spec
+  - id: access/copilot-api-service
+    target: copilot_api
+    apiVersion: v1
+    kind: Service
+    namespace: ai
+    name: copilot-api
+    r2_fields:
+      - spec
+  - id: access/copilot-api-ingress
+    target: copilot_api
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    namespace: ai
+    name: copilot-api
+    r2_fields:
+      - spec
+  - id: credentials/copilot-api
+    target: copilot_api
+    apiVersion: bitnami.com/v1alpha1
+    kind: SealedSecret
+    namespace: ai
+    name: copilot-api-secret
+    r2_fields:
+      - metadata.annotations
+
   - id: storage/arkham-pvc-storage
     target: arkham
     apiVersion: v1

--- a/tests/ci/test_critical_change_guard.py
+++ b/tests/ci/test_critical_change_guard.py
@@ -94,6 +94,26 @@ class CriticalChangeGuardTest(unittest.TestCase):
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertIn("permitted by a prior", completed.stdout)
 
+    def test_copilot_api_removal_requires_intents_for_every_rendered_resource(self) -> None:
+        kustomization = self.head / "apps/kyrion/ai/kustomization.yaml"
+        kustomization.write_text(
+            kustomization.read_text(encoding="utf-8")
+            .replace("  - ../../base/copilot-api\n", "")
+            .replace("  - copilot-api-sealed-secret.yaml\n", ""),
+            encoding="utf-8",
+        )
+        completed = self.run_guard()
+        self.assertNotEqual(completed.returncode, 0)
+        for resource_id in (
+            "storage/copilot-api-pvc",
+            "workload/copilot-api-deployment",
+            "access/copilot-api-service",
+            "access/copilot-api-ingress",
+            "credentials/copilot-api",
+        ):
+            self.assertIn(f"{resource_id} remove", completed.stdout)
+            self.assertIn("missing prior intent", completed.stdout)
+
     def test_bootstrap_dependency_change_fails_without_intent(self) -> None:
         manifest = self.head / "clusters/kyrion/apps.yaml"
         manifest.write_text(


### PR DESCRIPTION
## What changed

- Added the `apps/kyrion/ai` trusted render target to the critical GitOps policy.
- Added five Copilot API resource identities: PVC, Deployment, Service, Tailscale Ingress, and SealedSecret.
- Added a regression test proving that removing the Copilot base and its SealedSecret from the AI overlay creates five unapproved R2 removal events without prior intent.

## Why

Copilot API decommissioning includes persistent data and access-plane/credential resources. The current policy did not protect any of them, so the repository could not enforce the required two-PR R2 intent/consumption procedure. This is the policy-only prerequisite; it does not add an intent, remove any workload, access Secret data, or change cluster state.

## Validation

- `python3 scripts/ci/critical_change_guard.py --base . --head . --policy .github/critical-resources.yaml --report /tmp/copilot-critical-policy.json`
- `python3 -m unittest tests.ci.test_critical_change_guard` (19 tests)
- `python3 -m py_compile scripts/ci/*.py tests/ci/*.py`
- `bash -n scripts/ci/*.sh`
- `shellcheck scripts/ci/*.sh`
- `kustomize build apps/kyrion/ai`
- `yamllint .github/critical-resources.yaml`
- `git diff --check`

The eventual removal remains blocked on documented encrypted off-cluster backup evidence and an exercised restore drill, followed by the R2 intent PR and a separate removal PR.
