### PR TITLE
feat(ci): verify candidate local schemas

### DIFF
--- a/.github/workflows/pr-validate-ci-helpers.yml
+++ b/.github/workflows/pr-validate-ci-helpers.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Compile and test proposed Python helpers
         run: |
-          python3 -m py_compile scripts/ci/*.py tests/ci/test_pr_gate_helpers.py tests/ci/test_quality_ratchet.py tests/ci/test_quality_ratchet_shell.py tests/ci/test_split_rendered_manifests.py
-          python3 -m unittest tests.ci.test_pr_gate_helpers tests.ci.test_quality_ratchet tests.ci.test_quality_ratchet_shell tests.ci.test_split_rendered_manifests
+          python3 -m py_compile scripts/ci/*.py tests/ci/test_kubeconform_policy_effect_shell.py tests/ci/test_pr_gate_helpers.py tests/ci/test_quality_ratchet.py tests/ci/test_quality_ratchet_shell.py tests/ci/test_split_rendered_manifests.py
+          python3 -m unittest tests.ci.test_kubeconform_policy_effect_shell tests.ci.test_pr_gate_helpers tests.ci.test_quality_ratchet tests.ci.test_quality_ratchet_shell tests.ci.test_split_rendered_manifests
 
       - name: Parse and lint proposed shell helpers
         run: |

--- a/scripts/ci/run_kubeconform_policy_effect.sh
+++ b/scripts/ci/run_kubeconform_policy_effect.sh
@@ -100,6 +100,15 @@ base_catalog="https://raw.githubusercontent.com/datreeio/CRDs-catalog/${base_cat
 candidate_locations="$report_dir/candidate-schema-locations.txt"
 mkdir -p "$report_dir"
 
+if [ -d "$candidate_schemas_root" ]; then
+  test -f "$candidate_schemas_root/README.md"
+  test -f "$candidate_schemas_root/SHA256SUMS"
+  (
+    cd "$candidate_schemas_root"
+    sha256sum --check --strict SHA256SUMS
+  )
+fi
+
 python3 "$script_dir/resolve_kubeconform_schema_locations.py" \
   --workflow "$candidate_workflow" \
   --schemas-root "$candidate_schemas_root" \
@@ -114,17 +123,76 @@ if [ -d "$base_schemas_root" ]; then
 fi
 
 head_arguments=()
+candidate_kubeconform_arguments=()
 while IFS= read -r location; do
   test -n "$location" || {
     echo "Candidate kubeconform schema locations must not be empty." >&2
     exit 1
   }
   head_arguments+=(--head-schema-location "$location")
+  candidate_kubeconform_arguments+=(-schema-location "$location")
 done < "$candidate_locations"
 ((${#head_arguments[@]})) || {
   echo "Candidate kubeconform schema policy produced no schema locations." >&2
   exit 1
 }
+
+native_crd_schema="$candidate_schemas_root/apiextensions.k8s.io/customresourcedefinition_v1.json"
+if [ -e "$native_crd_schema" ]; then
+  test -f "$native_crd_schema"
+  fixture="$report_dir/invalid-native-customresourcedefinition.yaml"
+  negative_report="$report_dir/invalid-native-customresourcedefinition.json"
+  cat > "$fixture" <<'EOF'
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tests.example.invalid
+spec:
+  group: example.invalid
+  names:
+    kind: Test
+    plural: tests
+    singular: test
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+unexpectedTopLevel: true
+EOF
+  set +e
+  kubeconform -strict -output json -summary \
+    "${candidate_kubeconform_arguments[@]}" \
+    "$fixture" > "$negative_report" 2> "$negative_report.stderr"
+  negative_exit=$?
+  set -e
+  test "$negative_exit" -eq 1 || {
+    echo "Candidate native CRD schema must reject an unknown top-level property." >&2
+    exit 1
+  }
+  test ! -s "$negative_report.stderr" || {
+    sed -n '1,160p' "$negative_report.stderr" >&2
+    echo "kubeconform emitted stderr while checking the native CRD negative fixture." >&2
+    exit 1
+  }
+  python3 - "$negative_report" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+summary = payload.get("summary")
+resources = payload.get("resources")
+if not isinstance(summary, dict) or not isinstance(resources, list):
+    raise SystemExit("Native CRD negative fixture emitted malformed kubeconform JSON.")
+if summary.get("invalid") != 1 or summary.get("errors") != 0 or summary.get("skipped") != 0:
+    raise SystemExit("Native CRD negative fixture did not produce exactly one invalid result.")
+if len(resources) != 1 or resources[0].get("status") != "statusInvalid":
+    raise SystemExit("Native CRD negative fixture was not rejected as invalid.")
+PY
+fi
 
 arguments=(
   --tool kubeconform

--- a/tests/ci/test_kubeconform_policy_effect_shell.py
+++ b/tests/ci/test_kubeconform_policy_effect_shell.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Behavior tests for the trusted kubeconform policy-effect helper."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/ci/run_kubeconform_policy_effect.sh"
+CATALOG = "59abc9f9403c92e3d8f8873e250ca10dcd5b2c0d"
+
+
+class KubeconformPolicyEffectShellTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.rendered = self.root / "rendered"
+        self.rendered.mkdir()
+        self.base_schemas = self.root / "base-schemas"
+        self.candidate = self.root / "candidate"
+        self.candidate_schemas = self.candidate / ".github/schemas"
+        self.candidate_schemas.mkdir(parents=True)
+        workflow = self.candidate / ".github/workflows/pr-gate.yml"
+        workflow.parent.mkdir(parents=True)
+        workflow.write_text(f"env:\n  CRDS_CATALOG_COMMIT: {CATALOG}\n", encoding="utf-8")
+        self.workflow = workflow
+        self.report_dir = self.root / "reports"
+        self.binary_dir = self.root / "bin"
+        self.binary_dir.mkdir()
+        fake = self.binary_dir / "kubeconform"
+        fake.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "last=\"${!#}\"\n"
+            "if [[ \"$last\" == *invalid-native-customresourcedefinition.yaml ]]; then\n"
+            "  printf '%s\\n' '{\"resources\":[{\"status\":\"statusInvalid\"}],\"summary\":{\"valid\":0,\"invalid\":1,\"errors\":0,\"skipped\":0}}'\n"
+            "  exit 1\n"
+            "fi\n"
+            "printf '%s\\n' '{\"resources\":[],\"summary\":{\"valid\":1,\"invalid\":0,\"errors\":0,\"skipped\":0}}'\n",
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def add_candidate_schema_bundle(self, checksum: str | None = None) -> None:
+        schema = self.candidate_schemas / "apiextensions.k8s.io/customresourcedefinition_v1.json"
+        schema.parent.mkdir(parents=True)
+        schema.write_text('{"type":"object"}\n', encoding="utf-8")
+        actual = hashlib.sha256(schema.read_bytes()).hexdigest()
+        (self.candidate_schemas / "SHA256SUMS").write_text(
+            f"{checksum or actual}  apiextensions.k8s.io/customresourcedefinition_v1.json\n",
+            encoding="utf-8",
+        )
+        (self.candidate_schemas / "README.md").write_text("schema provenance\n", encoding="utf-8")
+
+    def run_helper(self) -> subprocess.CompletedProcess[str]:
+        environment = os.environ | {"PATH": f"{self.binary_dir}{os.pathsep}{os.environ['PATH']}"}
+        return subprocess.run(
+            [
+                "bash",
+                str(SCRIPT),
+                "--rendered-root",
+                str(self.rendered),
+                "--base-schemas-root",
+                str(self.base_schemas),
+                "--base-catalog-commit",
+                CATALOG,
+                "--candidate-workflow",
+                str(self.workflow),
+                "--candidate-schemas-root",
+                str(self.candidate_schemas),
+                "--base-sha",
+                "a" * 40,
+                "--head-sha",
+                "b" * 40,
+                "--report-dir",
+                str(self.report_dir),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=environment,
+        )
+
+    def test_candidate_native_schema_requires_verified_bundle_and_rejects_fixture(self) -> None:
+        self.add_candidate_schema_bundle()
+        completed = self.run_helper()
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertTrue((self.report_dir / "invalid-native-customresourcedefinition.json").is_file())
+
+    def test_candidate_schema_checksum_failure_fails_closed(self) -> None:
+        self.add_candidate_schema_bundle(checksum="0" * 64)
+        completed = self.run_helper()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("FAILED", completed.stdout + completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Extended the trusted kubeconform policy-effect helper to verify any proposed local-schema checksum bundle as inert data.
- When a candidate supplies the native `CustomResourceDefinition` schema, the trusted helper generates an invalid CRD fixture and requires kubeconform `-strict` to reject its unknown top-level property as `statusInvalid`, without skipped/errors.
- Added focused fake-kubeconform behavior tests and included them in the non-privileged CI-helper workflow.

## Why

This is a policy-only prerequisite for the subsequent strict native CRD schema artifact. Because `pull_request_target` only executes trusted-base helpers, this helper must merge before a schema artifact PR can prove its own negative fixture in the trusted policy-effect scan.

## Validation

- `python3 -m unittest tests.ci.test_kubeconform_policy_effect_shell tests.ci.test_pr_gate_helpers tests.ci.test_quality_ratchet tests.ci.test_quality_ratchet_shell tests.ci.test_split_rendered_manifests` (47 tests)
- `python3 -m py_compile scripts/ci/*.py tests/ci/test_kubeconform_policy_effect_shell.py tests/ci/test_pr_gate_helpers.py tests/ci/test_quality_ratchet.py tests/ci/test_quality_ratchet_shell.py tests/ci/test_split_rendered_manifests.py`
- `bash -n scripts/ci/*.sh`
- `shellcheck scripts/ci/*.sh`
- checksum-verified `actionlint 1.7.9 .github/workflows/pr-validate-ci-helpers.yml`
- `yamllint .github/workflows/pr-validate-ci-helpers.yml`
- `git diff --check`

No manifests, runtime resources, secrets, schemas, or cluster state are changed.
