### PR TITLE
fix(ci): allow SealedSecret ciphertext rotation

### DIFF
--- a/.github/workflows/pr-secret-scan.yml
+++ b/.github/workflows/pr-secret-scan.yml
@@ -1,7 +1,10 @@
 name: PR Secret Scan
 
 on:
-  pull_request:
+  # This workflow uses the default-branch definition so the scanner version,
+  # policy helper, and commands cannot be replaced by proposed PR content.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -10,16 +13,38 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  GITLEAKS_VERSION: 8.30.1
+  GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      # The proposed checkout is data only. The scanner and structural policy
+      # helper are checked out separately from the trusted PR base revision.
+      - name: Check out proposed content as data
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+      - name: Check out trusted base scanner and policy
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          persist-credentials: false
+
+      - name: Install YAML parser
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y python3-yaml
+
+      - name: Scan additions with trusted Gitleaks policy
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: bash base/scripts/ci/scan_added_diff_with_gitleaks.sh "$GITHUB_WORKSPACE"

--- a/.github/workflows/pr-validate-ci-helpers.yml
+++ b/.github/workflows/pr-validate-ci-helpers.yml
@@ -35,8 +35,21 @@ jobs:
 
       - name: Compile and test proposed Python helpers
         run: |
-          python3 -m py_compile scripts/ci/*.py tests/ci/test_kubeconform_policy_effect_shell.py tests/ci/test_pr_gate_helpers.py tests/ci/test_quality_ratchet.py tests/ci/test_quality_ratchet_shell.py tests/ci/test_split_rendered_manifests.py
-          python3 -m unittest tests.ci.test_kubeconform_policy_effect_shell tests.ci.test_pr_gate_helpers tests.ci.test_quality_ratchet tests.ci.test_quality_ratchet_shell tests.ci.test_split_rendered_manifests
+          python3 -m py_compile \
+            scripts/ci/*.py \
+            tests/ci/test_kubeconform_policy_effect_shell.py \
+            tests/ci/test_pr_gate_helpers.py \
+            tests/ci/test_quality_ratchet.py \
+            tests/ci/test_quality_ratchet_shell.py \
+            tests/ci/test_sealed_secret_ciphertext_policy.py \
+            tests/ci/test_split_rendered_manifests.py
+          python3 -m unittest \
+            tests.ci.test_kubeconform_policy_effect_shell \
+            tests.ci.test_pr_gate_helpers \
+            tests.ci.test_quality_ratchet \
+            tests.ci.test_quality_ratchet_shell \
+            tests.ci.test_sealed_secret_ciphertext_policy \
+            tests.ci.test_split_rendered_manifests
 
       - name: Parse and lint proposed shell helpers
         run: |

--- a/scripts/ci/quality_ratchet.py
+++ b/scripts/ci/quality_ratchet.py
@@ -24,6 +24,12 @@ try:
 except ImportError as error:  # pragma: no cover - exercised by CI dependency setup
     raise SystemExit(f"PyYAML is required by quality_ratchet.py: {error}")
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from sealed_secret_ciphertext_policy import ciphertext_ranges, redact_line
+
 
 class QualityRatchetError(RuntimeError):
     """Raised when a validator report is malformed or cannot be trusted."""
@@ -113,6 +119,7 @@ def parse_yamllint(report: Path, root: Path | None) -> list[Finding]:
         raise QualityRatchetError(f"Validator report is missing: {report}") from error
 
     findings: list[Finding] = []
+    source_cache: dict[Path, tuple[list[str], list[Any]]] = {}
     for raw in lines:
         if not raw.strip():
             continue
@@ -121,16 +128,24 @@ def parse_yamllint(report: Path, root: Path | None) -> list[Finding]:
             raise QualityRatchetError(f"Unrecognized yamllint parsable output: {raw!r}")
         relative = safe_relative_path(match.group("path"))
         source = root / relative
-        try:
-            source_lines = source.read_text(encoding="utf-8").splitlines()
-        except FileNotFoundError as error:
-            raise QualityRatchetError(f"yamllint finding references missing source file {relative}") from error
+        if source not in source_cache:
+            try:
+                source_content = source.read_text(encoding="utf-8")
+            except FileNotFoundError as error:
+                raise QualityRatchetError(f"yamllint finding references missing source file {relative}") from error
+            # Only a parsed, exact SealedSecret ciphertext scalar is normalized.
+            # Malformed or ambiguous YAML returns no ranges and retains the full
+            # source-line hash, so policy uncertainty cannot hide new debt.
+            source_cache[source] = (source_content.splitlines(), ciphertext_ranges(source_content))
+        source_lines, scalar_ranges = source_cache[source]
         line_number = int(match.group("line"))
         if not 1 <= line_number <= len(source_lines):
             raise QualityRatchetError(
                 f"yamllint finding references unavailable line {line_number} in {relative}"
             )
         offending_line = unicodedata.normalize("NFC", source_lines[line_number - 1])
+        if normalized_text(match.group("rule")) == "line-length":
+            offending_line = redact_line(offending_line, line_number, scalar_ranges)
         message_class = normalized_text(re.sub(r"\b[0-9]+\b", "<n>", match.group("message")))
         identity = "|".join(
             (

--- a/scripts/ci/scan_added_diff_with_gitleaks.sh
+++ b/scripts/ci/scan_added_diff_with_gitleaks.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 : "${RUNNER_TEMP:?RUNNER_TEMP is required}"
 
 repo="${1:-.}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 scanner_dir="$RUNNER_TEMP/gitleaks"
 archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
 
@@ -28,14 +29,17 @@ git -C "$repo" fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head:refs/rem
 test "$(git -C "$repo" rev-parse "$BASE_SHA")" = "$BASE_SHA"
 test "$(git -C "$repo" rev-parse refs/remotes/origin/pr-head)" = "$HEAD_SHA"
 
-# The --no-git file scan runs from scanner_dir, with config environment variables
-# unset and its ignore-file lookup confined there. That forces built-in Gitleaks
-# rules instead of PR-controlled .gitleaks.toml or .gitleaksignore content.
-git -C "$repo" diff --no-ext-diff --unified=0 "$BASE_SHA" "$HEAD_SHA" -- \
-  | awk '
-      /^@@ / { in_hunk = 1; next }
-      in_hunk && /^\+/ { sub(/^\+/, ""); print }
-    ' > "$scanner_dir/proposed.diff"
+# The policy helper retains every added line except direct scalar ciphertext in
+# an exact SealedSecret.spec.encryptedData location. It consumes trusted Git
+# objects as data and writes no source content to workflow output. The --no-git
+# file scan runs from scanner_dir, with config environment variables unset and
+# its ignore-file lookup confined there. That forces built-in Gitleaks rules
+# instead of PR-controlled .gitleaks.toml or .gitleaksignore content.
+python3 "$script_dir/sealed_secret_ciphertext_policy.py" filter-added-diff \
+  --repo "$repo" \
+  --base-sha "$BASE_SHA" \
+  --head-sha "$HEAD_SHA" \
+  --output "$scanner_dir/proposed.diff"
 (
   cd "$scanner_dir"
   env -u GITLEAKS_CONFIG -u GITLEAKS_CONFIG_TOML ./gitleaks detect \

--- a/scripts/ci/sealed_secret_ciphertext_policy.py
+++ b/scripts/ci/sealed_secret_ciphertext_policy.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Identify Bitnami SealedSecret ciphertext without suppressing other YAML content.
+
+This trusted CI helper recognizes only direct scalar values in
+``spec.encryptedData`` for a YAML document whose top-level ``kind`` is exactly
+``SealedSecret``. It deliberately fails closed: malformed YAML, duplicate keys,
+aliases, and unsupported structures receive no ciphertext treatment.
+
+The helper never prints source content. Its diff-filter command writes a private
+Gitleaks input file containing all added lines, with only recognized ciphertext
+scalar segments replaced by a fixed non-secret marker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+try:
+    import yaml
+except ImportError as error:  # pragma: no cover - exercised by CI dependency setup
+    raise SystemExit(f"PyYAML is required by sealed_secret_ciphertext_policy.py: {error}")
+
+
+CIPHERTEXT_MARKER = "<sealed-secret-ciphertext>"
+HUNK_HEADER = re.compile(r"^@@ -[0-9]+(?:,[0-9]+)? \+(?P<line>[0-9]+)(?:,[0-9]+)? @@")
+
+
+class CiphertextPolicyError(RuntimeError):
+    """Raised when trusted Git data cannot be processed safely."""
+
+
+@dataclass(frozen=True)
+class SourceRange:
+    """A half-open scalar range expressed in zero-based YAML source locations."""
+
+    start_line: int
+    start_column: int
+    end_line: int
+    end_column: int
+
+
+def is_yaml_path(path: str) -> bool:
+    return path.lower().endswith((".yaml", ".yml"))
+
+
+def unique_mapping_value(mapping: yaml.MappingNode, expected_key: str) -> yaml.Node | None:
+    """Return a direct mapping value only when the key appears exactly once."""
+    matches = [
+        value
+        for key, value in mapping.value
+        if isinstance(key, yaml.ScalarNode) and key.value == expected_key
+    ]
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+def direct_scalar_value(
+    content: str, key: yaml.Node, value: yaml.Node
+) -> SourceRange | None:
+    """Return a source range only for an unaliased direct ``key: scalar`` value."""
+    if not isinstance(key, yaml.ScalarNode) or not isinstance(value, yaml.ScalarNode):
+        return None
+    if value.start_mark.index < key.end_mark.index:
+        return None
+
+    between = content[key.end_mark.index : value.start_mark.index]
+    if not re.fullmatch(r":[ \t]*(?:\r?\n[ \t]*)*", between):
+        # Anchors, aliases, comments before a continuation value, and other
+        # unsupported representations remain scanner-visible.
+        return None
+
+    return SourceRange(
+        start_line=value.start_mark.line,
+        start_column=value.start_mark.column,
+        end_line=value.end_mark.line,
+        end_column=value.end_mark.column,
+    )
+
+
+def mapping_keys_are_unambiguous(node: yaml.Node | None, seen: set[int] | None = None) -> bool:
+    """Reject duplicate, complex, and non-string mapping keys anywhere in a document."""
+    if node is None:
+        return True
+    if seen is None:
+        seen = set()
+    if id(node) in seen:
+        return True
+    seen.add(id(node))
+
+    if isinstance(node, yaml.MappingNode):
+        keys: set[str] = set()
+        for key, value in node.value:
+            if (
+                not isinstance(key, yaml.ScalarNode)
+                or key.tag != "tag:yaml.org,2002:str"
+                or key.value in keys
+            ):
+                return False
+            keys.add(key.value)
+            if not mapping_keys_are_unambiguous(value, seen):
+                return False
+        return True
+    if isinstance(node, yaml.SequenceNode):
+        return all(mapping_keys_are_unambiguous(value, seen) for value in node.value)
+    return True
+
+
+def contains_alias(content: str) -> bool:
+    """Treat YAML aliases as unsupported rather than resolving their source marks."""
+    try:
+        return any(isinstance(event, yaml.events.AliasEvent) for event in yaml.parse(content))
+    except yaml.YAMLError:
+        return True
+
+
+def document_ciphertext_ranges(content: str, document: yaml.Node | None) -> list[SourceRange]:
+    """Return direct SealedSecret ciphertext ranges for one parsed document."""
+    if not isinstance(document, yaml.MappingNode):
+        return []
+
+    kind = unique_mapping_value(document, "kind")
+    if not isinstance(kind, yaml.ScalarNode) or kind.value != "SealedSecret":
+        return []
+
+    spec = unique_mapping_value(document, "spec")
+    if not isinstance(spec, yaml.MappingNode):
+        return []
+    encrypted_data = unique_mapping_value(spec, "encryptedData")
+    if not isinstance(encrypted_data, yaml.MappingNode):
+        return []
+
+    keys: set[str] = set()
+    ranges: list[SourceRange] = []
+    for key, value in encrypted_data.value:
+        # Duplicate or complex keys make the selected structure ambiguous. Do
+        # not exempt any values from this document in that case.
+        if not isinstance(key, yaml.ScalarNode) or key.value in keys:
+            return []
+        keys.add(key.value)
+        scalar_range = direct_scalar_value(content, key, value)
+        if scalar_range is not None:
+            ranges.append(scalar_range)
+    return ranges
+
+
+def ciphertext_ranges(content: str) -> list[SourceRange]:
+    """Return recognized ciphertext ranges, or none when parsing is unsafe."""
+    if contains_alias(content):
+        return []
+    try:
+        documents = list(yaml.compose_all(content))
+    except yaml.YAMLError:
+        return []
+
+    ranges: list[SourceRange] = []
+    for document in documents:
+        if not mapping_keys_are_unambiguous(document):
+            # One malformed or ambiguous document invalidates the file-wide
+            # exemption, so a mixed multi-document file cannot hide content.
+            return []
+        ranges.extend(document_ciphertext_ranges(content, document))
+    return ranges
+
+
+def redact_line(line: str, line_number: int, ranges: Iterable[SourceRange]) -> str:
+    """Replace recognized scalar portions of one 1-based source line with a marker."""
+    replacements: list[tuple[int, int]] = []
+    zero_based_line = line_number - 1
+    for source_range in ranges:
+        if zero_based_line < source_range.start_line or zero_based_line > source_range.end_line:
+            continue
+        start = source_range.start_column if zero_based_line == source_range.start_line else 0
+        end = source_range.end_column if zero_based_line == source_range.end_line else len(line)
+        start = min(max(start, 0), len(line))
+        end = min(max(end, start), len(line))
+        replacements.append((start, end))
+
+    if not replacements:
+        return line
+
+    # Valid YAML scalar node ranges cannot overlap. Treat an unexpected overlap
+    # as unsafe rather than coalescing it into an exemption.
+    replacements.sort()
+    if any(right[0] < left[1] for left, right in zip(replacements, replacements[1:])):
+        return line
+
+    chunks: list[str] = []
+    cursor = 0
+    for start, end in replacements:
+        chunks.append(line[cursor:start])
+        chunks.append(CIPHERTEXT_MARKER)
+        cursor = end
+    chunks.append(line[cursor:])
+    return "".join(chunks)
+
+
+def git(repo: Path, *arguments: str) -> bytes:
+    completed = subprocess.run(
+        ["git", *arguments], cwd=repo, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    if completed.returncode != 0:
+        raise CiphertextPolicyError("Unable to calculate the trusted base-to-head diff")
+    return completed.stdout
+
+
+def changed_paths(repo: Path, base_sha: str, head_sha: str) -> list[str]:
+    raw = git(
+        repo,
+        "diff",
+        "--name-only",
+        "-z",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-renames",
+        "--diff-filter=ACMR",
+        base_sha,
+        head_sha,
+        "--",
+    )
+    fields = raw.split(b"\0")
+    if fields and fields[-1] == b"":
+        fields.pop()
+
+    paths: list[str] = []
+    for field in fields:
+        try:
+            path = field.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise CiphertextPolicyError("Trusted diff contains a non-UTF-8 path") from error
+        candidate = PurePosixPath(path)
+        if candidate.is_absolute() or ".." in candidate.parts or not path:
+            raise CiphertextPolicyError("Trusted diff contains an unsafe path")
+        paths.append(path)
+    return paths
+
+
+def added_lines(repo: Path, base_sha: str, head_sha: str, path: str) -> list[tuple[int, str]]:
+    try:
+        patch = git(
+            repo,
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--text",
+            "--no-renames",
+            "--unified=0",
+            base_sha,
+            head_sha,
+            "--",
+            path,
+        ).decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise CiphertextPolicyError("Trusted diff contains non-UTF-8 content") from error
+
+    result: list[tuple[int, str]] = []
+    head_line: int | None = None
+    for raw_line in patch.splitlines():
+        match = HUNK_HEADER.match(raw_line)
+        if match is not None:
+            head_line = int(match.group("line"))
+            continue
+        if head_line is None:
+            continue
+        if raw_line.startswith("\\ No newline at end of file"):
+            continue
+        if raw_line.startswith("+"):
+            result.append((head_line, raw_line[1:]))
+            head_line += 1
+        elif raw_line.startswith("-"):
+            continue
+        elif raw_line.startswith(" "):
+            head_line += 1
+        else:
+            raise CiphertextPolicyError("Trusted diff contains an unexpected hunk record")
+    return result
+
+
+def head_ciphertext_ranges(repo: Path, head_sha: str, path: str) -> list[SourceRange]:
+    if not is_yaml_path(path):
+        return []
+    try:
+        content = git(repo, "show", f"{head_sha}:{path}").decode("utf-8")
+    except (CiphertextPolicyError, UnicodeDecodeError):
+        # A malformed or non-text YAML candidate remains entirely scanner-visible.
+        return []
+    return ciphertext_ranges(content)
+
+
+def filtered_added_lines(repo: Path, base_sha: str, head_sha: str) -> list[str]:
+    """Return every added line, replacing only recognized ciphertext segments."""
+    result: list[str] = []
+    for path in changed_paths(repo, base_sha, head_sha):
+        ranges = head_ciphertext_ranges(repo, head_sha, path)
+        for line_number, line in added_lines(repo, base_sha, head_sha, path):
+            result.append(redact_line(line, line_number, ranges))
+    return result
+
+
+def write_filtered_added_diff(repo: Path, base_sha: str, head_sha: str, output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as stream:
+        for line in filtered_added_lines(repo, base_sha, head_sha):
+            stream.write(line)
+            stream.write("\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    filter_parser = subparsers.add_parser("filter-added-diff")
+    filter_parser.add_argument("--repo", type=Path, required=True)
+    filter_parser.add_argument("--base-sha", required=True)
+    filter_parser.add_argument("--head-sha", required=True)
+    filter_parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        write_filtered_added_diff(args.repo, args.base_sha, args.head_sha, args.output)
+    except CiphertextPolicyError as error:
+        print(f"::error title=SealedSecret ciphertext policy integrity error::{error}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_quality_ratchet.py
+++ b/tests/ci/test_quality_ratchet.py
@@ -116,6 +116,63 @@ class QualityRatchetTest(unittest.TestCase):
         self.assertEqual(state, "FAIL: NEW DEBT")
         self.assertEqual(sum(added.values()), 1)
 
+    def test_yamllint_sealed_secret_ciphertext_rotation_retains_line_length_debt(self) -> None:
+        base_content = """apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: ciphertext-before-marker-that-is-deliberately-long-for-the-line-length-ratchet
+"""
+        head_content = """apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: ciphertext-after-marker-that-is-deliberately-long-for-the-line-length-ratchet
+"""
+        self.write(self.base, "apps/example.yaml", base_content)
+        self.write(self.head, "apps/example.yaml", head_content)
+        base_report = self.report(
+            "base-yamllint.txt", "apps/example.yaml:5:1: [warning] line too long (130 > 120 characters) (line-length)\n"
+        )
+        head_report = self.report(
+            "head-yamllint.txt", "apps/example.yaml:5:1: [warning] line too long (130 > 120 characters) (line-length)\n"
+        )
+        state, added, removed, _, _ = QUALITY.summarize(
+            "yamllint",
+            QUALITY.parse_yamllint(base_report, self.base),
+            QUALITY.parse_yamllint(head_report, self.head),
+        )
+        self.assertEqual(state, "PASS WITH EXISTING DEBT")
+        self.assertFalse(added)
+        self.assertFalse(removed)
+
+    def test_yamllint_sealed_secret_encrypted_data_key_change_is_new_debt(self) -> None:
+        base_content = """kind: SealedSecret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: ciphertext-marker-that-is-deliberately-long-for-the-line-length-ratchet
+"""
+        head_content = """kind: SealedSecret
+spec:
+  encryptedData:
+    RENAMED_TOKEN: ciphertext-marker-that-is-deliberately-long-for-the-line-length-ratchet
+"""
+        self.write(self.base, "apps/example.yaml", base_content)
+        self.write(self.head, "apps/example.yaml", head_content)
+        base_report = self.report(
+            "base-yamllint.txt", "apps/example.yaml:4:1: [warning] line too long (130 > 120 characters) (line-length)\n"
+        )
+        head_report = self.report(
+            "head-yamllint.txt", "apps/example.yaml:4:1: [warning] line too long (130 > 120 characters) (line-length)\n"
+        )
+        state, added, _, _, _ = QUALITY.summarize(
+            "yamllint",
+            QUALITY.parse_yamllint(base_report, self.base),
+            QUALITY.parse_yamllint(head_report, self.head),
+        )
+        self.assertEqual(state, "FAIL: NEW DEBT")
+        self.assertEqual(sum(added.values()), 1)
+
     def test_yamllint_duplicate_occurrence_is_new_debt(self) -> None:
         finding = QUALITY.Finding("same", "same")
         state, added, _, _, _ = QUALITY.summarize("yamllint", [finding], [finding, finding])

--- a/tests/ci/test_sealed_secret_ciphertext_policy.py
+++ b/tests/ci/test_sealed_secret_ciphertext_policy.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Focused boundary tests for SealedSecret ciphertext CI policy."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/ci/sealed_secret_ciphertext_policy.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("sealed_secret_ciphertext_policy", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+POLICY = load_module()
+
+
+class CiphertextStructureTest(unittest.TestCase):
+    def redact(self, content: str) -> list[str]:
+        ranges = POLICY.ciphertext_ranges(content)
+        return [POLICY.redact_line(line, number, ranges) for number, line in enumerate(content.splitlines(), start=1)]
+
+    def test_only_exact_sealed_secret_encrypted_data_scalar_is_redacted(self) -> None:
+        content = """apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    token: metadata-token-marker
+spec:
+  encryptedData:
+    SERVICE_TOKEN: ciphertext-marker # an outside comment marker
+  template:
+    metadata:
+      name: demo
+"""
+        redacted = self.redact(content)
+        self.assertIn("    SERVICE_TOKEN: <sealed-secret-ciphertext> # an outside comment marker", redacted)
+        self.assertIn("    token: metadata-token-marker", redacted)
+        self.assertNotIn("ciphertext-marker", "\n".join(redacted))
+        self.assertIn("SERVICE_TOKEN", "\n".join(redacted))
+
+    def test_plaintext_secret_and_nonmatching_kind_are_not_redacted(self) -> None:
+        for kind in ("Secret", "sealedsecret"):
+            content = f"""apiVersion: v1
+kind: {kind}
+spec:
+  encryptedData:
+    SERVICE_TOKEN: ciphertext-marker
+"""
+            self.assertEqual(POLICY.ciphertext_ranges(content), [])
+
+    def test_other_sealed_secret_fields_and_nested_documents_are_not_redacted(self) -> None:
+        content = """apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: ciphertext-marker
+spec:
+  template:
+    metadata:
+      annotations:
+        token: ciphertext-marker
+---
+items:
+  - kind: SealedSecret
+    spec:
+      encryptedData:
+        SERVICE_TOKEN: ciphertext-marker
+"""
+        self.assertEqual(POLICY.ciphertext_ranges(content), [])
+
+    def test_malformed_duplicate_and_alias_input_fail_closed(self) -> None:
+        malformed = """kind: SealedSecret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: [ciphertext-marker
+"""
+        duplicate_root = """kind: SealedSecret
+kind: SealedSecret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: ciphertext-marker
+"""
+        duplicate_encrypted_data_key = """kind: SealedSecret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: ciphertext-marker
+    SERVICE_TOKEN: different-ciphertext-marker
+"""
+        duplicate_metadata_key = """kind: SealedSecret
+metadata:
+  name: first
+  name: second
+spec:
+  encryptedData:
+    SERVICE_TOKEN: ciphertext-marker
+"""
+        alias = """kind: SealedSecret
+metadata:
+  annotations:
+    source: &ciphertext ciphertext-marker
+spec:
+  encryptedData:
+    SERVICE_TOKEN: *ciphertext
+"""
+        for content in (malformed, duplicate_root, duplicate_encrypted_data_key, duplicate_metadata_key, alias):
+            self.assertEqual(POLICY.ciphertext_ranges(content), [])
+
+    def test_block_scalar_value_keeps_the_key_and_redacts_its_content(self) -> None:
+        content = """kind: SealedSecret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: |
+      ciphertext-first-marker
+      ciphertext-second-marker
+"""
+        redacted = self.redact(content)
+        self.assertEqual(redacted[3], "    SERVICE_TOKEN: <sealed-secret-ciphertext>")
+        self.assertEqual(redacted[4], "<sealed-secret-ciphertext>")
+        self.assertEqual(redacted[5], "<sealed-secret-ciphertext>")
+
+
+class FilteredDiffTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tempdir.name) / "repo"
+        self.repo.mkdir()
+        self.run_git("init")
+        self.run_git("config", "user.email", "ci@example.invalid")
+        self.run_git("config", "user.name", "CI Test")
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def run_git(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(["git", *arguments], cwd=self.repo, text=True, capture_output=True, check=True)
+
+    def write_and_commit(self, content: str, message: str) -> str:
+        path = self.repo / "apps/example/secret.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        self.run_git("add", ".")
+        self.run_git("commit", "-m", message)
+        return self.run_git("rev-parse", "HEAD").stdout.strip()
+
+    def test_diff_hides_only_rotated_sealed_secret_ciphertext(self) -> None:
+        base = self.write_and_commit(
+            """kind: SealedSecret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: ciphertext-before-marker
+""",
+            "base",
+        )
+        head = self.write_and_commit(
+            """kind: SealedSecret
+metadata:
+  annotations:
+    token: outside-token-marker
+spec:
+  encryptedData:
+    SERVICE_TOKEN: ciphertext-after-marker
+""",
+            "head",
+        )
+        filtered = "\n".join(POLICY.filtered_added_lines(self.repo, base, head))
+        self.assertIn("    SERVICE_TOKEN: <sealed-secret-ciphertext>", filtered)
+        self.assertIn("outside-token-marker", filtered)
+        self.assertNotIn("ciphertext-after-marker", filtered)
+
+    def test_cli_does_not_print_or_write_recognized_ciphertext(self) -> None:
+        base = self.write_and_commit(
+            """kind: SealedSecret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: ciphertext-before-marker
+""",
+            "base",
+        )
+        head = self.write_and_commit(
+            """kind: SealedSecret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: ciphertext-after-marker
+""",
+            "head",
+        )
+        output = self.repo / "filtered.diff"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "filter-added-diff",
+                "--repo",
+                str(self.repo),
+                "--base-sha",
+                base,
+                "--head-sha",
+                head,
+                "--output",
+                str(output),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+        filtered = output.read_text(encoding="utf-8")
+        self.assertIn("SERVICE_TOKEN: <sealed-secret-ciphertext>", filtered)
+        self.assertNotIn("ciphertext-after-marker", filtered)
+
+    def test_diff_forces_text_when_proposed_attributes_disable_yaml_diffs(self) -> None:
+        base = self.write_and_commit("kind: ConfigMap\n", "base")
+        (self.repo / ".gitattributes").write_text("*.yaml -diff\n", encoding="utf-8")
+        (self.repo / "apps/example/secret.yaml").write_text(
+            """kind: Secret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: plaintext-token-marker
+""",
+            encoding="utf-8",
+        )
+        self.run_git("add", ".")
+        self.run_git("commit", "-m", "attributes")
+        head = self.run_git("rev-parse", "HEAD").stdout.strip()
+        filtered = "\n".join(POLICY.filtered_added_lines(self.repo, base, head))
+        self.assertIn("plaintext-token-marker", filtered)
+
+    def test_diff_keeps_plaintext_secret_and_malformed_yaml_visible(self) -> None:
+        base = self.write_and_commit("kind: ConfigMap\n", "base")
+        head = self.write_and_commit(
+            """kind: Secret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: plaintext-token-marker
+""",
+            "plaintext",
+        )
+        plaintext = "\n".join(POLICY.filtered_added_lines(self.repo, base, head))
+        self.assertIn("plaintext-token-marker", plaintext)
+
+        malformed_base = head
+        malformed_head = self.write_and_commit(
+            """kind: SealedSecret
+spec:
+  encryptedData:
+    SERVICE_TOKEN: malformed-token-marker
+    invalid: [
+""",
+            "malformed",
+        )
+        malformed = "\n".join(POLICY.filtered_added_lines(self.repo, malformed_base, malformed_head))
+        self.assertIn("malformed-token-marker", malformed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Added one trusted structural policy helper for Bitnami `SealedSecret` ciphertext.
- `yamllint` line-length debt now fingerprints an exact `SealedSecret.spec.encryptedData` scalar with a fixed marker, so ciphertext rotation does not become new debt. The encrypted-data key, metadata, comments, and every other field remain part of the identity.
- The trusted Gitleaks diff scanner now sends every added line to its checksum-verified scanner except that same exact scalar segment, which is replaced with a non-secret marker in its private scanner input.
- Updated the standalone **PR Secret Scan** to use the same trusted-base helper under `pull_request_target`, and added the focused test module to the CI-helper workflow.

## Security boundary

The exception is limited to a direct scalar under `spec.encryptedData` in a YAML document whose top-level `kind` is exactly `SealedSecret`.

- Plaintext `kind: Secret`, metadata, encrypted-data keys, comments, nested objects, non-YAML files, and all values outside the exact location continue to be scanned/ratcheted.
- Malformed YAML, aliases, duplicate/complex/non-string mapping keys anywhere in a document, and unsupported scalar representations receive **no** exemption (fail closed).
- Diff extraction uses `--no-ext-diff --no-textconv --text`, so proposed `.gitattributes` cannot hide changed additions from Gitleaks.
- The helper does not print source content; focused tests verify recognized ciphertext is replaced by a marker in the scanner input and absent from helper stdout/stderr.

## Validation

Passed locally:

```text
python3 -m py_compile scripts/ci/*.py tests/ci/*.py
python3 -m unittest \
  tests.ci.test_kubeconform_policy_effect_shell \
  tests.ci.test_pr_gate_helpers \
  tests.ci.test_quality_ratchet \
  tests.ci.test_quality_ratchet_shell \
  tests.ci.test_sealed_secret_ciphertext_policy \
  tests.ci.test_split_rendered_manifests
# 58 tests passed
bash -n scripts/ci/*.sh
shellcheck scripts/ci/*.sh
yamllint -d <repo-config-without-ignore-paths> \
  .github/workflows/pr-secret-scan.yml \
  .github/workflows/pr-validate-ci-helpers.yml
actionlint .github/workflows/pr-secret-scan.yml .github/workflows/pr-validate-ci-helpers.yml
git diff --check
```

This branch has one commit, `0ad08317a9bf707d8b2a5ed5c40b2fbd9a5c2af1`, directly on `origin/main` (`4e5c57c657ac84d2a0d8ebe14d1e96c06a9ea920`). It contains no Grafana MCP manifest change and does not include PR #131's token-rotation commit.
