### PR TITLE
feat(backup): add K8up backup platform

### DIFF
--- a/docs/runbooks/backup-and-restore.md
+++ b/docs/runbooks/backup-and-restore.md
@@ -1,8 +1,137 @@
 # Backup, restore, and out-of-band recovery contract
 
 > **Status: design and verification work is tracked in issue #90.** This runbook
-> intentionally does not claim that a local PVC named `pvc-backups` is an
-> off-cluster backup or that any restore drill has completed.
+> does not claim that a configured Schedule is a recoverable backup. That claim
+> requires a successful backup, repository check, and restore drill.
+
+## K8up and Restic baseline
+
+K8up is the cluster backup operator and Restic is the repository format and
+encryption engine used by the Jobs it creates. Restic does not require a
+separate controller or installation. The baseline intentionally avoids object
+storage, storage plugins, custom backup images, and repository wrapper scripts.
+
+Each protected namespace receives:
+
+- one dedicated directory below the private host backup root;
+- one static local `PersistentVolume` with reclaim policy `Retain`;
+- one namespace-scoped repository PVC;
+- one unique Restic password delivered as a SealedSecret;
+- one or more K8up Schedules selecting only the intended workload PVCs.
+
+The public repository uses placeholders for node names and host paths. Keep the
+real mount path, filesystem UUID, node identity, capacity evidence, and preflight
+results in the private operational log. A typical private layout is:
+
+```text
+<backup-root>/<namespace>
+```
+
+Do not share a repository directory or password between namespaces. Store a
+recovery copy of every Restic password in an external password manager; the
+SealedSecret alone is tied to the cluster sealing key and is not sufficient for
+disaster recovery.
+
+The local external disk protects against loss of a workload PVC or its primary
+disk. It does not protect against theft, fire, or a root compromise of the host.
+This residual risk is acceptable for this homelab, but a local repository must
+not be described as an off-site backup.
+
+## Recovery objectives and retention
+
+The shared baseline is:
+
+| Objective | Baseline |
+|---|---|
+| Backup schedule | Every 6 hours |
+| Maximum accepted backup age | 24 hours |
+| Restore target | Within 2 hours |
+| Retention | 4 hourly, 7 daily, 5 weekly, 12 monthly |
+| Repository check | Weekly |
+| Prune | Weekly, separated from the check window |
+
+K8up's official ServiceMonitor and chart-managed rules cover failed Jobs, the
+latest scheduled backup failing, and namespaces with an active Schedule but no
+Job in the last 24 hours. They use only operator and kube-state-metrics data.
+Detailed per-backup Restic metrics require a Pushgateway and are intentionally
+not part of this baseline. A missing alert is not proof of recoverability;
+verify the repository and perform restore drills.
+
+## Trusted-host preflight
+
+Before adding a local repository PV, verify from the host that the private
+backup root is the intended filesystem, is mounted read-write, and has adequate
+free space. Create only the namespace child directory with the reviewed owner,
+group, and setgid permissions. Confirm with a disposable file that the UID and
+supplemental GID used by K8up Jobs can create and remove repository data.
+
+Record the filesystem UUID and test result privately. Do not change the parent
+directory, publish infrastructure identifiers, or merge the PV until this
+preflight succeeds.
+
+## Onboard a PVC
+
+Keep K8up `Schedule` resources, repository PVCs, and SealedSecrets in the owning
+application overlay. A Schedule must:
+
+- select only the intended PVC label;
+- mount the namespace repository PVC at the backend's local mount path;
+- reference the Secret key `password` for Restic encryption;
+- apply the shared retention, deadline, history, and resource limits;
+- run backup, check, and prune in distinct reviewed windows.
+
+Do not modify an application's existing PVC merely to onboard backup. After
+reconciliation, verify that the repository PV and PVC are `Bound`, the Schedule
+is ready, the backup Job succeeded, the expected PVC path has a snapshot, the
+check completed, and the repository directory contains Restic data.
+
+Live filesystem backup does not guarantee application consistency. Databases
+and stateful applications must pass native integrity checks after restore. If a
+restore exposes SQLite, configuration, permission, or startup errors, switch to
+an application-aware or stopped backup; do not weaken the drill criteria.
+
+## Restore drill
+
+Never restore over the production PVC during a drill. Create the scratch PVC,
+K8up `Restore`, deny-all NetworkPolicy, read-only verification Job, and offline
+application pod temporarily through GitOps. Select the tested snapshot
+timestamp privately and publish no snapshot identifier or restored content.
+
+Validate file count and aggregate size, a deterministic aggregate checksum,
+ownership and modes, configuration parsing, native database integrity, and an
+offline application startup. Record only timestamps, duration, aggregate
+counts, results, and RPO/RTO compliance. Remove all drill-only resources in a
+follow-up GitOps change while preserving the Schedule, repository PV/PVC,
+password, and Restic data.
+
+## Operator-independent Restic recovery
+
+The repository remains usable without K8up. On a trusted Linux host, mount the
+external disk, retrieve the password from the external password manager, and
+use the standard Restic CLI against the namespace repository:
+
+```bash
+export RESTIC_PASSWORD_FILE=<protected-password-file>
+restic --repo <repository-path> snapshots
+restic --repo <repository-path> check
+restic --repo <repository-path> restore latest --target <temporary-restore-directory>
+```
+
+Run restore into a new temporary directory and apply the same integrity checks
+as a Kubernetes drill. Do not put the password on the command line or run
+`forget`, `prune`, `unlock`, or repository deletion as part of fallback
+validation.
+
+## Rollback K8up
+
+Remove Schedules first and wait for active Jobs to finish. Preserve repository
+PVs, PVCs, SealedSecrets, external password-manager entries, and all Restic
+data. The PV reclaim policy must remain `Retain`.
+
+Remove every K8up custom resource before uninstalling the operator. Verify the
+repository with the Restic CLI before completing the rollback. Never automate
+`restic forget`, manual prune, repository initialization, or directory deletion
+during rollback.
 
 ## Required contract before an R2 data change
 
@@ -55,16 +184,6 @@ Changes](destructive-gitops-change.md) or [GitHub Merge-Control
 Break-Glass](github-break-glass.md) as appropriate. These controls cannot prove
 an out-of-band channel exists: the channel's test date, operator, and result must
 remain in the private operational log.
-
-## Restore drill
-
-A restore drill must be carried out before any destructive storage migration:
-
-1. Restore a representative backup into an isolated target or approved recovery
-   window.
-2. Validate application integrity and access without exposing secrets in logs.
-3. Measure actual recovery time and compare it with the workload RTO.
-4. Record gaps, rotate exposed credentials if applicable, and update the contract.
 
 ## Related documentation
 

--- a/infrastructure/controllers/k8up/README.md
+++ b/infrastructure/controllers/k8up/README.md
@@ -1,0 +1,12 @@
+# K8up controller
+
+K8up provides the shared PVC backup, retention, integrity-check, prune, and
+restore API. Restic runs inside K8up's generated Jobs; it is not installed as a
+separate cluster component.
+
+The official chart owns the K8up CRDs, ServiceMonitor, and PrometheusRule. The
+configured alerts use only operator and kube-state-metrics data, so they do not
+require a Pushgateway. Application schedules and repository credentials remain
+with the owning application overlay. See the [backup and restore
+runbook](../../../docs/runbooks/backup-and-restore.md) for the local-repository
+contract and operator-independent Restic recovery.

--- a/infrastructure/controllers/k8up/kustomization.yaml
+++ b/infrastructure/controllers/k8up/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - release.yaml

--- a/infrastructure/controllers/k8up/namespace.yaml
+++ b/infrastructure/controllers/k8up/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8up-system

--- a/infrastructure/controllers/k8up/release.yaml
+++ b/infrastructure/controllers/k8up/release.yaml
@@ -1,0 +1,76 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: k8up
+  namespace: k8up-system
+spec:
+  interval: 1h
+  timeout: 10m
+  chart:
+    spec:
+      chart: k8up
+      version: "4.10.0"
+      sourceRef:
+        kind: HelmRepository
+        name: k8up
+        namespace: k8up-system
+  install:
+    crds: Create
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  values:
+    metrics:
+      serviceMonitor:
+        enabled: true
+        scrapeInterval: 60s
+      prometheusRule:
+        enabled: true
+        createDefaultRules: false
+        additionalLabels:
+          release: kube-prometheus-stack
+        additionalRules:
+          - alert: K8upJobFailed
+            expr: >-
+              (sum(kube_job_status_failed) by (job_name, namespace)
+              * on (job_name, namespace) group_right()
+              kube_job_labels{label_k8up_io_type=~"archive|backup|check|prune|restore"}) > 0
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              summary: >-
+                K8up {{ $labels.label_k8up_io_type }} Job failed in
+                {{ $labels.namespace }}
+          - alert: K8upBackupLastRunFailed
+            expr: k8up_schedule_last_job_succeeded{jobType="backup"} == 0
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              summary: >-
+                Latest scheduled backup {{ $labels.schedule }} failed in
+                {{ $labels.exported_namespace }}
+          - alert: K8upBackupNotRunning
+            expr: >-
+              (k8up_schedules_gauge > 0)
+              unless on (exported_namespace)
+              (sum by (exported_namespace) (increase(k8up_jobs_total[24h])) > 0)
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              summary: >-
+                No K8up Job ran in {{ $labels.exported_namespace }} during the
+                last 24 hours despite an active Schedule
+    resources:
+      requests:
+        cpu: 20m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi

--- a/infrastructure/controllers/k8up/repository.yaml
+++ b/infrastructure/controllers/k8up/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: k8up
+  namespace: k8up-system
+spec:
+  interval: 24h
+  url: https://k8up-io.github.io/k8up

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - arc
   - flux-operator
   - flux-operator-mcp
+  - k8up


### PR DESCRIPTION
## Summary

Add phase 1 of the reusable K8up + Restic backup platform for #90 and the OpenClaw backup tracked in #121.

- install the official K8up chart 4.10.0 in `k8up-system`, with chart-managed CRDs
- enable the official ServiceMonitor and a chart-managed PrometheusRule
- alert on failed K8up Jobs, the latest scheduled backup failing, and no Job within 24 hours while a Schedule is active
- document the local per-namespace Restic repository contract, trusted-host preflight, restore drills, operator-independent Restic fallback, and safe rollback

This PR intentionally does not add a Schedule, PV/PVC, SealedSecret, host path, node identifier, or any OpenClaw resource change. No backup starts in this phase.

## Monitoring note

K8up's `k8up_backup_restic_last_errors` metric is emitted only through Pushgateway. Because this design intentionally has no Pushgateway, the alert uses the operator-native `k8up_schedule_last_job_succeeded` metric instead. The upstream no-job expression was also adjusted to preserve the exported namespace and detect absent series. No custom metric or monitoring component is introduced.

## Validation

- official chart archive SHA-256 matched the Helm repository index
- `helm template` K8up 4.10.0 with CRDs and configured values
- `kubectl kustomize infrastructure/controllers/k8up`
- `kubectl kustomize infrastructure/controllers`
- `kubectl kustomize clusters/kyrion/infrastructure/controllers`
- `flux build kustomization infra-controllers --path clusters/kyrion/infrastructure/controllers --kustomization-file clusters/kyrion/infrastructure.yaml --dry-run`
- `kubectl kustomize apps/kyrion/ai`
- `flux build kustomization apps --path apps/kyrion --kustomization-file clusters/kyrion/apps.yaml --dry-run`
- `yamllint` on changed Kubernetes YAML
- `promtool check rules` using the cluster's Prometheus 3.13.2 image
- `git diff --check`
- checked the diff for plaintext secrets and infrastructure identifiers

## Rollout gate

Merge and verify the K8up HelmRelease, CRDs, ServiceMonitor, PrometheusRule, and inactive alerts before opening phase 2 for the OpenClaw repository and Schedule.

Relates to #90.
Part of #121.