### PR TITLE
fix(system-upgrade): pin k3s release

### DIFF
--- a/infrastructure/configs/system-upgrade/k3s-upgrade.yaml
+++ b/infrastructure/configs/system-upgrade/k3s-upgrade.yaml
@@ -11,7 +11,8 @@ metadata:
     k3s-upgrade: server
 spec:
   concurrency: 1 # Batch size (roughly maps to maximum number of unschedulable nodes)
-  channel: https://update.k3s.io/v1-release/channels/latest
+  # renovate: k3s
+  version: "v1.36.3+k3s1"
   nodeSelector:
     matchExpressions:
       - {key: k3s-upgrade, operator: Exists}
@@ -43,7 +44,8 @@ metadata:
     k3s-upgrade: agent
 spec:
   concurrency: 2 # Batch size (roughly maps to maximum number of unschedulable nodes)
-  channel: https://update.k3s.io/v1-release/channels/latest
+  # renovate: k3s
+  version: "v1.36.3+k3s1"
   nodeSelector:
     matchExpressions:
       - {key: k3s-upgrade, operator: Exists}
@@ -66,3 +68,4 @@ spec:
     startTime: "02:00"
     endTime: "04:00"
     timeZone: "Europe/Rome"
+  jobActiveDeadlineSecs: 1800  # 30 minuti

--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,19 @@
       "matchStrings": [
         "\"(?<currentValue>[a-zA-Z0-9._-]+)\"\\s*#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+extractVersion=(?<extractVersion>\\S+))?(?:\\s+versioning=(?<versioning>\\S+))?[ \\t]*(?:\\r?\\n|$)"
       ]
+    },
+    {
+      "description": "Pinned K3s versions in System Upgrade Controller Plans",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^infrastructure/configs/system-upgrade/k3s-upgrade\\.yaml$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*k3s\\s+version:\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "k3s-io/k3s",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)\\+k3s(?<build>\\d+)$"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Change and risk

- [x] I identified the affected domain(s): GitOps.
- [x] I ran the applicable local validation commands and recorded them below.
- [ ] User approval is pending; this PR intentionally has auto-merge disabled.
- [x] The user explicitly approved head SHA `ba099bd3c73001c6cd0692dd42aed8df923dd62c` for merge; I then enabled native auto-merge with `gh pr merge --auto --squash`.

This change pins both System Upgrade Controller Plans to K3s
`v1.36.3+k3s1` instead of resolving a mutable runtime channel. Renovate will
propose future stable K3s releases as reviewable PRs and update the server and
agent Plans together. The agent Plan now has the same 30-minute Job deadline
as the server Plan.

The change prevents a transient channel regression from selecting an older
K3s upgrade image and replacing the host binary. It does not modify the live
cluster; reconciliation occurs only after the control plane is recovered.

## Quality ratchet

- [ ] No new yamllint, kubeconform, or Kubernetes Checkov debt was introduced; I reviewed the PR Gate quality-ratchet summary.
- [ ] This PR reduces inherited quality debt; I recorded the validator/report result below. *(Optional.)*
- [ ] This is a quality-policy change only; it does not also change manifests or functions evaluated by that policy.

## Critical / destructive changes

- [ ] Not applicable.
- [x] This is R1: the System Upgrade Controller Plans control host-level K3s binary replacement. The change replaces runtime channel resolution with an exact Git-reviewed release pin.
- [ ] This is R2: I followed `docs/runbooks/destructive-gitops-change.md`, including the required two-PR intent/consumption sequence and backup/rollback evidence.

## Validation evidence

- `kubectl kustomize infrastructure/configs/system-upgrade`
- `kubectl kustomize clusters/kyrion/infrastructure/configs`
- `yamllint infrastructure/configs/system-upgrade/k3s-upgrade.yaml`
- `renovate-config-validator renovate.json`
- Renovate local dry-run: exit 0; detected `k3s-io/k3s` at
  `v1.36.3+k3s1` in exactly two Plan occurrences.
- `git diff --check`

Both rendered Plans contain `version: v1.36.3+k3s1`, no `channel`, and
`jobActiveDeadlineSecs: 1800`.

## Rollback

Revert commit `ba099bd3c73001c6cd0692dd42aed8df923dd62c` through a reviewed PR.
Do not restore the mutable channel while recovering the current incident;
retain the exact known-good pin until the host is stable and the replacement
upgrade policy has been reviewed.
