### PR TITLE
feat(ci): add simple validation shadow gate

### DIFF
--- a/.github/workflows/pr-validate-simple.yml
+++ b/.github/workflows/pr-validate-simple.yml
@@ -208,17 +208,12 @@ jobs:
         env:
           TF_IN_AUTOMATION: "true"
         run: |
-          printf '%s\n' \
-            jupyterlab \
-            kubernetes \
-            kubernetes-devcontainer \
-            kubernetes-envbox \
-            mux \
-            mux-cache-canary \
-            ubuntu-desktop > "$RUNNER_TEMP/coder-templates"
-          bash scripts/ci/validate_coder_templates.sh \
-            --root "$GITHUB_WORKSPACE" \
-            --template-file "$RUNNER_TEMP/coder-templates"
+          set -euo pipefail
+          while IFS= read -r -d '' directory; do
+            terraform -chdir="$directory" fmt -check -recursive
+            terraform -chdir="$directory" init -backend=false -input=false
+            terraform -chdir="$directory" validate -no-color
+          done < <(find coder/templates -mindepth 1 -maxdepth 1 -type d ! -name '.*' -print0 | sort -z)
 
       - name: Install actionlint
         if: steps.changes.outputs.actions-scripts == 'true'

--- a/.github/workflows/pr-validate-simple.yml
+++ b/.github/workflows/pr-validate-simple.yml
@@ -94,10 +94,10 @@ jobs:
           grep -qx '  namespace: arc-runners' "$exception"
           grep -qx '    kubernetes.io/service-account.name: copilot-agent-readonly' "$exception"
           grep -qx 'type: kubernetes.io/service-account-token' "$exception"
-          grep -qE '^[[:space:]]*(data|stringData):' "$exception" && {
+          if grep -qE '^[[:space:]]*(data|stringData):' "$exception"; then
             echo "::error file=$exception::The service-account-token Secret scaffold must not define data."
-            exit 1;
-          }
+            exit 1
+          fi
 
       - name: Set up Flux CLI
         if: steps.changes.outputs.gitops == 'true'

--- a/.github/workflows/pr-validate-simple.yml
+++ b/.github/workflows/pr-validate-simple.yml
@@ -35,22 +35,23 @@ jobs:
 
       - name: Detect optional validation domains
         id: changes
-        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        # The repository permits GitHub-owned and verified Actions, but not the
+        # external paths-filter Action. Keep the classifier small and visible.
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          filters: |
-            gitops:
-              - 'apps/**'
-              - 'clusters/**'
-              - 'infrastructure/**'
-              - 'monitoring/**'
-              - '.github/schemas/**'
-            charts:
-              - 'charts/**'
-            coder:
-              - 'coder/templates/**'
-            actions-scripts:
-              - '.github/workflows/**'
-              - 'scripts/**/*.sh'
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const hasPrefix = (...prefixes) => files.some(({ filename }) =>
+              prefixes.some((prefix) => filename.startsWith(prefix)));
+            core.setOutput('gitops', hasPrefix(
+              'apps/', 'clusters/', 'infrastructure/', 'monitoring/', '.github/schemas/'));
+            core.setOutput('charts', hasPrefix('charts/'));
+            core.setOutput('coder', hasPrefix('coder/templates/'));
+            core.setOutput('actions-scripts', hasPrefix('.github/workflows/', 'scripts/'));
 
       - name: Install YAML linter
         run: |

--- a/.github/workflows/pr-validate-simple.yml
+++ b/.github/workflows/pr-validate-simple.yml
@@ -1,0 +1,240 @@
+name: PR Validate Simple
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-validate-simple-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  KUSTOMIZE_VERSION: v5.8.1
+  KUSTOMIZE_SHA256: 029a7f0f4e1932c52a0476cf02a0fd855c0bb85694b82c338fc648dcb53a819d
+  KUBECONFORM_VERSION: v0.8.0
+  KUBECONFORM_SHA256: 9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883
+  CRDS_CATALOG_COMMIT: 59abc9f9403c92e3d8f8873e250ca10dcd5b2c0d
+  GITLEAKS_VERSION: 8.30.1
+  ACTIONLINT_VERSION: 1.7.9
+  ACTIONLINT_SHA256: 233b280d05e100837f4af1433c7b40a5dcb306e3aa68fb4f17f8a7f45a7df7b4
+
+jobs:
+  validate:
+    name: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect optional validation domains
+        id: changes
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          filters: |
+            gitops:
+              - 'apps/**'
+              - 'clusters/**'
+              - 'infrastructure/**'
+              - 'monitoring/**'
+              - '.github/schemas/**'
+            charts:
+              - 'charts/**'
+            coder:
+              - 'coder/templates/**'
+            actions-scripts:
+              - '.github/workflows/**'
+              - 'scripts/**/*.sh'
+
+      - name: Install YAML linter
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y yamllint
+
+      - name: Lint YAML
+        run: yamllint .
+
+      - name: Scan pull request changes for leaked secrets
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITLEAKS_VERSION: ${{ env.GITLEAKS_VERSION }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_ENABLE_COMMENTS: "false"
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
+
+      - name: Reject changed plaintext Secret manifests
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          exception='infrastructure/configs/ci/copilot-agent-rbac/secret.yaml'
+          changed_yaml="$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- \
+            apps clusters functions infrastructure monitoring | grep -E '\.ya?ml$' || true)"
+          unexpected="$(printf '%s\n' "$changed_yaml" | xargs -r grep -lE \
+            '^[[:space:]]*kind:[[:space:]]*Secret[[:space:]]*$' 2>/dev/null | \
+            grep -vFx "$exception" || true)"
+          test -z "$unexpected" || {
+            echo "::error::Bare kind: Secret manifests are not allowed: $unexpected"
+            exit 1;
+          }
+          test -f "$exception"
+          grep -qx 'apiVersion: v1' "$exception"
+          grep -qx 'kind: Secret' "$exception"
+          grep -qx '  name: copilot-agent-readonly-token' "$exception"
+          grep -qx '  namespace: arc-runners' "$exception"
+          grep -qx '    kubernetes.io/service-account.name: copilot-agent-readonly' "$exception"
+          grep -qx 'type: kubernetes.io/service-account-token' "$exception"
+          grep -qE '^[[:space:]]*(data|stringData):' "$exception" && {
+            echo "::error file=$exception::The service-account-token Secret scaffold must not define data."
+            exit 1;
+          }
+
+      - name: Set up Flux CLI
+        if: steps.changes.outputs.gitops == 'true'
+        uses: fluxcd/flux2/action@889be9d6cc8afa8ed639e1e1ba4ab678e3b38d8c # v2.9.4
+
+      - name: Install kustomize and kubeconform
+        if: steps.changes.outputs.gitops == 'true'
+        run: |
+          set -euo pipefail
+          curl -fsSL -o kustomize.tar.gz \
+            "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          echo "${KUSTOMIZE_SHA256}  kustomize.tar.gz" | sha256sum --check --strict
+          tar -xzf kustomize.tar.gz
+          sudo install -m 0755 kustomize /usr/local/bin/kustomize
+          curl -fsSL -o kubeconform.tar.gz \
+            "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz"
+          echo "${KUBECONFORM_SHA256}  kubeconform.tar.gz" | sha256sum --check --strict
+          tar -xzf kubeconform.tar.gz kubeconform
+          sudo install -m 0755 kubeconform /usr/local/bin/kubeconform
+
+      - name: Verify local kubeconform schemas
+        if: steps.changes.outputs.gitops == 'true'
+        working-directory: .github/schemas
+        run: sha256sum --check --strict SHA256SUMS
+
+      - name: Render Flux root composition
+        if: steps.changes.outputs.gitops == 'true'
+        run: kustomize build clusters/kyrion/ > /dev/null
+
+      - name: Validate apps render
+        if: steps.changes.outputs.gitops == 'true'
+        run: |
+          flux build kustomization apps --path ./apps/kyrion \
+            --kustomization-file clusters/kyrion/apps.yaml --dry-run |
+            kubeconform -strict -summary \
+              -schema-location default \
+              -schema-location '.github/schemas/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+              -schema-location "https://raw.githubusercontent.com/datreeio/CRDs-catalog/${CRDS_CATALOG_COMMIT}/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+
+      - name: Validate infrastructure controllers render
+        if: steps.changes.outputs.gitops == 'true'
+        run: |
+          flux build kustomization infra-controllers --path ./clusters/kyrion/infrastructure/controllers \
+            --kustomization-file clusters/kyrion/infrastructure.yaml --dry-run |
+            kubeconform -strict -summary \
+              -schema-location default \
+              -schema-location '.github/schemas/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+              -schema-location "https://raw.githubusercontent.com/datreeio/CRDs-catalog/${CRDS_CATALOG_COMMIT}/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+
+      - name: Validate infrastructure configuration render
+        if: steps.changes.outputs.gitops == 'true'
+        run: |
+          flux build kustomization infra-configs --path ./clusters/kyrion/infrastructure/configs \
+            --kustomization-file clusters/kyrion/infrastructure.yaml --dry-run |
+            kubeconform -strict -summary \
+              -schema-location default \
+              -schema-location '.github/schemas/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+              -schema-location "https://raw.githubusercontent.com/datreeio/CRDs-catalog/${CRDS_CATALOG_COMMIT}/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+
+      - name: Validate monitoring controllers render
+        if: steps.changes.outputs.gitops == 'true'
+        run: |
+          flux build kustomization monitoring-controllers --path ./clusters/kyrion/monitoring/controllers \
+            --kustomization-file clusters/kyrion/monitoring.yaml --dry-run |
+            kubeconform -strict -summary \
+              -schema-location default \
+              -schema-location '.github/schemas/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+              -schema-location "https://raw.githubusercontent.com/datreeio/CRDs-catalog/${CRDS_CATALOG_COMMIT}/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+
+      - name: Validate monitoring configuration render
+        if: steps.changes.outputs.gitops == 'true'
+        run: |
+          flux build kustomization monitoring-configs --path ./monitoring/configs \
+            --kustomization-file clusters/kyrion/monitoring.yaml --dry-run |
+            kubeconform -strict -summary \
+              -schema-location default \
+              -schema-location '.github/schemas/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+              -schema-location "https://raw.githubusercontent.com/datreeio/CRDs-catalog/${CRDS_CATALOG_COMMIT}/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+
+      - name: Set up Helm
+        if: steps.changes.outputs.charts == 'true'
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: Lint local charts
+        if: steps.changes.outputs.charts == 'true'
+        run: |
+          helm lint charts/cron-job
+          helm lint charts/onechart
+
+      - name: Install helm-unittest
+        if: steps.changes.outputs.charts == 'true'
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2 --verify=false
+
+      - name: Test local charts
+        if: steps.changes.outputs.charts == 'true'
+        run: |
+          helm unittest charts/cron-job
+          helm unittest charts/onechart
+
+      - name: Set up Terraform
+        if: steps.changes.outputs.coder == 'true'
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_wrapper: false
+
+      - name: Validate Coder templates
+        if: steps.changes.outputs.coder == 'true'
+        env:
+          TF_IN_AUTOMATION: "true"
+        run: |
+          printf '%s\n' \
+            jupyterlab \
+            kubernetes \
+            kubernetes-devcontainer \
+            kubernetes-envbox \
+            mux \
+            mux-cache-canary \
+            ubuntu-desktop > "$RUNNER_TEMP/coder-templates"
+          bash scripts/ci/validate_coder_templates.sh \
+            --root "$GITHUB_WORKSPACE" \
+            --template-file "$RUNNER_TEMP/coder-templates"
+
+      - name: Install actionlint
+        if: steps.changes.outputs.actions-scripts == 'true'
+        run: |
+          set -euo pipefail
+          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
+          echo "${ACTIONLINT_SHA256}  ${archive}" | sha256sum --check --strict
+          tar -xzf "$archive" actionlint
+          sudo install -m 0755 actionlint /usr/local/bin/actionlint
+
+      - name: Lint GitHub Actions workflows
+        if: steps.changes.outputs.actions-scripts == 'true'
+        run: actionlint .github/workflows/*.yml .github/workflows/*.yaml
+
+      - name: Check shell syntax
+        if: steps.changes.outputs.actions-scripts == 'true'
+        run: |
+          bash -n scripts/ci/*.sh scripts/collect-monitoring-baseline.sh
+          sh -n scripts/bootstrap_flux.sh scripts/rotate-oidc-sealed-secrets.sh

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+title = "Elysium Gitleaks configuration"
+
+[extend]
+useDefault = true
+
+# Bitnami SealedSecret ciphertext is intentionally committed. Gitleaks sees
+# lines rather than YAML structure, so this accepts only a complete
+# ciphertext-shaped scalar line; other plaintext in the same manifest remains
+# scanned by the default rules.
+[[allowlists]]
+description = "Bitnami SealedSecret ciphertext"
+regexTarget = "line"
+regexes = ['''^\s*[A-Za-z0-9_.-]+:\s+Ag[A-Za-z0-9+/=]+(?:\s+#.*)?$''']

--- a/apps/base/copilot-api/copilot-api.yaml
+++ b/apps/base/copilot-api/copilot-api.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: copilot-api-data
+  annotations:
+    # Keep application state if the workload is removed from a Flux inventory.
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: copilot-api
     app.kubernetes.io/instance: copilot-api

--- a/apps/kyrion/ai/namespace.yaml
+++ b/apps/kyrion/ai/namespace.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ai
+  annotations:
+    # Prevent namespace pruning from cascading to AI workloads and backup state.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/apps/kyrion/ai/openclaw-backup-repository-pv.yaml
+++ b/apps/kyrion/ai/openclaw-backup-repository-pv.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: openclaw-backup-repository
+  annotations:
+    # Retain the backup repository if its source inventory is damaged.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   accessModes:
     - ReadWriteOnce

--- a/apps/kyrion/ai/openclaw-backup-repository-pvc.yaml
+++ b/apps/kyrion/ai/openclaw-backup-repository-pvc.yaml
@@ -3,6 +3,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: openclaw-backup-repository
   namespace: ai
+  annotations:
+    # Retain the backup repository claim until deliberate GitOps cleanup.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   accessModes:
     - ReadWriteOnce

--- a/apps/kyrion/ai/openclaw-backup-repository-sealed-secret.yaml
+++ b/apps/kyrion/ai/openclaw-backup-repository-sealed-secret.yaml
@@ -4,6 +4,9 @@ kind: SealedSecret
 metadata:
   name: openclaw-backup-repository
   namespace: ai
+  annotations:
+    # Keep the repository credential available for recovery reconciliation.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   encryptedData:
     # yamllint disable-line rule:line-length

--- a/apps/kyrion/ai/openclaw-backup-schedule.yaml
+++ b/apps/kyrion/ai/openclaw-backup-schedule.yaml
@@ -3,6 +3,9 @@ kind: Schedule
 metadata:
   name: openclaw-backup
   namespace: ai
+  annotations:
+    # Keep scheduled backup, check, and retention jobs after a source-inventory error.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   backend:
     local:

--- a/apps/kyrion/arkham/namespace.yaml
+++ b/apps/kyrion/arkham/namespace.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: arkham
+  annotations:
+    # Prevent namespace pruning from cascading to Arkham data and workloads.
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/apps/kyrion/arkham/pvc.yaml
+++ b/apps/kyrion/arkham/pvc.yaml
@@ -4,6 +4,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-storage
   namespace: arkham
+  annotations:
+    # Preserve Arkham data if a source inventory entry is removed accidentally.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   accessModes:
     - ReadWriteOnce
@@ -18,6 +21,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-downloads
   namespace: arkham
+  annotations:
+    # Preserve Arkham data if a source inventory entry is removed accidentally.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   accessModes:
     - ReadWriteOnce
@@ -32,6 +38,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-watch
   namespace: arkham
+  annotations:
+    # Preserve Arkham data if a source inventory entry is removed accidentally.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   accessModes:
     - ReadWriteOnce
@@ -46,6 +55,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-library
   namespace: arkham
+  annotations:
+    # Preserve Arkham data if a source inventory entry is removed accidentally.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   accessModes:
     - ReadWriteOnce
@@ -60,6 +72,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-backups
   namespace: arkham
+  annotations:
+    # Preserve Arkham data if a source inventory entry is removed accidentally.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   accessModes:
     - ReadWriteOnce
@@ -73,6 +88,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-plex-logs
   namespace: arkham
+  annotations:
+    # Preserve Arkham data if a source inventory entry is removed accidentally.
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   accessModes:
     - ReadWriteOnce

--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -16,7 +16,9 @@ The shadow workflow always runs yamllint, Gitleaks, and a source-level guard for
 new or changed `kind: Secret` documents. It validates the Flux root and five
 actual Flux apply surfaces with strict kubeconform only for GitOps changes, and
 runs local-chart, Coder Terraform, or Actions/script checks only for their
-respective paths through the maintained `dorny/paths-filter` action. It has no
+respective paths. A short `actions/github-script` step queries the PR file list:
+it replaces an external path-filter Action that is not permitted by the repository
+Actions policy, without reintroducing a repository helper. The workflow has no
 base/head quality ratchet, Checkov, custom report parser, critical-resource diff
 engine, or fan-in state machine.
 

--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -3,6 +3,36 @@
 This document describes the GitHub Actions workflows that validate pull requests before merge.
 See `AGENTS.md` for the full command reference used by these workflows.
 
+## Simple-gate shadow rollout
+
+`PR Validate Simple / validate` is the non-required shadow gate for the
+simplification rollout. It runs from `pull_request` with a read-only token, no
+repository or environment secrets, and no cluster access. The workflow treats a
+PR as reviewable homelab configuration rather than hostile code; the existing
+trusted-base **PR Gate** remains the required merge boundary until the shadow
+workflow passes the canary matrix and the ruleset is migrated.
+
+The shadow workflow always runs yamllint, Gitleaks, and a source-level guard for
+new or changed `kind: Secret` documents. It validates the Flux root and five
+actual Flux apply surfaces with strict kubeconform only for GitOps changes, and
+runs local-chart, Coder Terraform, or Actions/script checks only for their
+respective paths through the maintained `dorny/paths-filter` action. It has no
+base/head quality ratchet, Checkov, custom report parser, critical-resource diff
+engine, or fan-in state machine.
+
+`.gitleaks.toml` permits only a complete Bitnami SealedSecret ciphertext-shaped
+scalar line; normal plaintext in the same YAML file remains scanned. Because
+Gitleaks evaluates line syntax rather than YAML structure, a deliberately added
+plaintext value matching that ciphertext shape is an accepted, narrow residual
+risk. The tracked `apps/base/coder/secret.yaml` is historical plaintext-Secret
+debt and is not allowed to change. It requires a separate credential rotation
+and SealedSecret/native-reference migration before the simplified source-level
+guard can be made whole-tree strict.
+
+Do not make `PR Validate Simple / validate` required or remove `PR Gate /
+required` until a fresh canary PR validates documentation-only, GitOps,
+SealedSecret rotation, chart, Coder, and Actions/script changes.
+
 ## Current merge boundary
 
 The repository uses one always-present monorepo workflow: **PR Gate**. Its

--- a/infrastructure/configs/tsidp/viewer-clusterrolebinding.yaml
+++ b/infrastructure/configs/tsidp/viewer-clusterrolebinding.yaml
@@ -2,6 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tsidp-viewer
+  annotations:
+    # Keep the recovery access binding if an upstream inventory is damaged.
+    kustomize.toolkit.fluxcd.io/prune: disabled
   labels:
     app.kubernetes.io/name: tsidp
     app.kubernetes.io/component: rbac


### PR DESCRIPTION
## What changed

- Added `PR Validate Simple / validate` as a non-required `pull_request` shadow gate with direct upstream validation tools.
- Uses short GitHub-owned `actions/github-script` file-list classification because the repository Actions policy does not allow the external `dorny/paths-filter` Action.
- Fixes the service-account-token Secret scaffold check so absent `data`/`stringData` passes under Bash `-e`.
- Added Flux-native prune protections for high-impact data, backup, namespace, and recovery-access resources.
- Added a narrow Gitleaks configuration for Bitnami SealedSecret ciphertext and documented its explicit residual risk.
- Kept `PR Gate / required`, existing trusted-base checks, and all legacy workflows unchanged until hosted canaries prove the shadow workflow.

## Validation

- `yamllint .` (historical line-length warnings only)
- `actionlint .github/workflows/*.yml .github/workflows/*.yaml`
- `git diff --check` and `git show --check`
- 85 existing CI helper tests plus shell syntax/ShellCheck
- Flux render and strict kubeconform for apps, infrastructure controllers/configs, monitoring controllers/configs
- `helm lint` and 122 `helm unittest` tests
- Terraform validation for all seven Coder templates
- Gitleaks fixture tests and a temporary base/head simulation of the existing YAML ratchet plus critical guard
- Classifier behavior test, GitHub Actions policy verification, and a base/head reproduction of the Secret scaffold guard including a negative fixture

## Hosted validation

At head `9aa20dfaf3cb0f42665c5a788c51e10554231bed`, `PR Validate Simple / validate` and `PR Gate / required` are successful. The first legacy Coder job attempt hit a transient Git shallow-fetch error; GitHub Actions retry attempt 2 completed successfully without a source change.

## Rollout

This PR is intentionally shadow-only. Do not add `PR Validate Simple / validate` to the required ruleset or remove `PR Gate / required` until fresh hosted canaries cover docs, GitOps, SealedSecret rotation, charts, Coder, and Actions/scripts.

## Approval

- User approval: received on August 18, 2026
- Approved head SHA: `83afc99be4713e8eef0536b488ca47a0e0f04cf4`
- Merge method: native GitHub squash auto-merge
- Merge completed: August 18, 2026
