### PR TITLE
docs(ci): clarify current required context

### DIFF
--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -37,8 +37,8 @@ SealedSecret rotation, chart, Coder, and Actions/script changes.
 
 ## Current merge boundary
 
-The repository uses one always-present monorepo workflow: **PR Gate**. Its
-**`required`** job detects the paths changed by a PR, runs baseline and applicable
+The repository's current required merge boundary is **`PR Gate / required`**.
+Its **`required`** job detects the paths changed by a PR, runs baseline and applicable
 domain validators, and fails closed when a selected validator does not succeed. The
 ruleset requires this one job context rather than path-filtered workflow contexts.
 


### PR DESCRIPTION
## Purpose

Docs-only post-merge canary for `PR Validate Simple / validate`. It corrects the documentation to identify the currently required context precisely while exercising only the shadow gate baseline checks.

## Expected simple-gate behavior

- Run: YAML lint, Gitleaks, and the source-level Secret guard.
- Skip: Flux/kubeconform, Helm, Coder Terraform, actionlint, and shell syntax checks.
- Keep `PR Gate / required` as the sole required context.

## Approval

- User approval: pending
- Approved head SHA: pending