### PR TITLE
feat(ci): freeze Flux bootstrap sources

### DIFF
--- a/.github/workflows/flux-bootstrap-guard.yml
+++ b/.github/workflows/flux-bootstrap-guard.yml
@@ -1,0 +1,49 @@
+name: Flux Bootstrap Guard
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: flux-bootstrap-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject changes to immutable Flux bootstrap files
+        # `pull_request_target` executes this GitHub-owned Action from the trusted
+        # default branch. It queries PR metadata only and never checks out or runs
+        # proposed content.
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const protectedPaths = new Set([
+              '.github/workflows/flux-bootstrap-guard.yml',
+              'clusters/kyrion/kustomization.yaml',
+              'clusters/kyrion/apps.yaml',
+              'clusters/kyrion/infrastructure.yaml',
+              'clusters/kyrion/monitoring.yaml',
+              'infrastructure/configs/flux-instance/kustomization.yaml',
+              'infrastructure/configs/flux-instance/repository.yaml',
+              'infrastructure/configs/flux-instance/release.yaml',
+            ]);
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const changed = files.filter(({ filename, previous_filename }) =>
+              protectedPaths.has(filename) || protectedPaths.has(previous_filename));
+            if (changed.length > 0) {
+              core.setFailed(
+                'Flux bootstrap files are immutable in normal PR flow: ' +
+                changed.map(({ filename, previous_filename }) =>
+                  previous_filename ? `${previous_filename} -> ${filename}` : filename).join(', ') +
+                '. Use docs/runbooks/github-break-glass.md for an approved recovery change.');
+            }

--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -35,6 +35,31 @@ Do not make `PR Validate Simple / validate` required or remove `PR Gate /
 required` until a fresh canary PR validates documentation-only, GitOps,
 SealedSecret rotation, chart, Coder, and Actions/script changes.
 
+## Flux bootstrap guard rollout
+
+`Flux Bootstrap Guard / guard` is a deliberately narrow, trusted-base
+`pull_request_target` workflow for the Flux reconciliation trust root. It reads only
+the GitHub pull-request file list with a read-only token; it does not check out or
+execute proposed content.
+
+The guard rejects any normal PR that changes one of these immutable paths:
+
+- `.github/workflows/flux-bootstrap-guard.yml`;
+- `clusters/kyrion/kustomization.yaml`, `apps.yaml`, `infrastructure.yaml`, or
+  `monitoring.yaml`;
+- `infrastructure/configs/flux-instance/kustomization.yaml`, `repository.yaml`, or
+  `release.yaml`.
+
+Those files define the Flux root composition, child reconciliation paths, and the
+FluxInstance chart and `instance.sync` source. Freezing whole files keeps this guard
+small and avoids recreating the retired critical-resource diff engine, report parsers,
+or policy ratchet. A legitimate bootstrap recovery or source change uses the
+break-glass procedure; ordinary application and infrastructure changes are unaffected.
+
+The workflow is introduced before it becomes a required check. After a harmless
+canary proves it runs from `main`, the ruleset will require both this `guard` job and
+`PR Validate Simple / validate`.
+
 ## Current merge boundary
 
 The repository uses one always-present monorepo workflow: **PR Gate**. Its

--- a/docs/runbooks/github-break-glass.md
+++ b/docs/runbooks/github-break-glass.md
@@ -7,24 +7,24 @@ pushes to `main`.
 
 ## When it is allowed
 
-Use break-glass only when `PR Gate / required` is itself defective or unavailable
-and blocks the repair PR. It is not a response to a failed application deployment,
-a slow reconciliation, or an inconvenient validation result.
+Use break-glass only when a required validation check—`PR Validate Simple /
+validate` or `Flux Bootstrap Guard / guard`—is itself defective or unavailable and
+blocks the repair PR. It is not a response to a failed application deployment, a
+slow reconciliation, or an inconvenient validation result.
 
 ## Procedure
 
 1. Record the incident in issue #87 with the failing check, commit SHA, time, and
    intended repair. Do not include private network identifiers or credentials.
-2. In GitHub repository Rules, remove **only** `PR Gate / required` from the
-   `Protection` ruleset. Keep pull-request-only, deletion, and non-fast-forward
-   rules active and do not add a bypass actor.
+2. In GitHub repository Rules, remove **only** the failing required context from
+   the `Protection` ruleset. Keep the other required checks, pull-request-only,
+   deletion, and non-fast-forward rules active and do not add a bypass actor.
 3. Open a PR that repairs the gate. Run every applicable validator locally and
    attach the exact commands/results to the PR.
 4. Enable native squash auto-merge. Do not use `--admin` and do not push directly
    to `main`.
-5. Immediately restore `PR Gate / required` in the ruleset after the repair is on
-   `main`.
-6. Open a harmless follow-up PR to confirm the repaired gate runs and succeeds.
+5. Immediately restore the removed required context after the repair is on `main`.
+6. Open a harmless follow-up PR to confirm the repaired check runs and succeeds.
 7. Update issue #87 with the restoration time and validation result.
 
 ## If GitHub itself is unavailable
@@ -36,7 +36,7 @@ in this runbook.
 
 ## Exit criteria
 
-- The ruleset again requires PRs and `PR Gate / required`.
-- The bypass list is empty.
-- A test PR runs the gate from the current default branch.
+- The ruleset again requires PRs and every intended required check.
+- The bypass list is unchanged.
+- A test PR runs the repaired check from the current default branch.
 - The incident record identifies why break-glass was used and when it ended.


### PR DESCRIPTION
## What changed

- Adds `Flux Bootstrap Guard / guard`, a small trusted-base `pull_request_target` workflow that reads only GitHub PR file metadata with a read-only token and never checks out or runs proposed content.
- Freezes the Flux root composition, child reconciliation paths, FluxInstance chart/source files, and the guard workflow itself.
- Updates PR-validation and break-glass documentation for the narrow guard.

## Why this is separate

The prior cleanup PR #142 removes the broad legacy critical-diff engine. Review identified that rendering/schema validation alone cannot reject a syntactically valid edit to `FluxInstance.spec.values.instance.sync` that moves future reconciliation to another source. This guard handles only that special trust boundary; it does not restore Checkov, quality ratchets, intent files, render-diff parsers, or R1/R2 classification.

## Rollout

The guard cannot run from its own first PR because `pull_request_target` executes the workflow from trusted `main`. After merge, a harmless PR will prove it runs from `main`; only then will `guard` be added as a second required context alongside `validate`. Cleanup PR #142 remains draft until that sequence finishes.

## Validation

- fixture test covering unrelated files, protected file changes, guard self-change, and protected-file rename
- `yamllint .github/workflows/flux-bootstrap-guard.yml`
- checksum-pinned `actionlint .github/workflows/flux-bootstrap-guard.yml`
- `git diff --check` and `git show --check`

## Approval

- User approval: received on August 18, 2026
- Approved head SHA: `52a51d89af97b7316776dca574e5c4beca03527d`
- Merge method: native GitHub squash auto-merge
