### PR TITLE
fix(ci): freeze System Upgrade source

### DIFF
--- a/.github/workflows/flux-bootstrap-guard.yml
+++ b/.github/workflows/flux-bootstrap-guard.yml
@@ -32,6 +32,7 @@ jobs:
               'infrastructure/configs/flux-instance/kustomization.yaml',
               'infrastructure/configs/flux-instance/repository.yaml',
               'infrastructure/configs/flux-instance/release.yaml',
+              'infrastructure/controllers/system-upgrade/controller.yaml',
             ]);
             const files = await github.paginate(github.rest.pulls.listFiles, {
               ...context.repo,

--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -48,10 +48,12 @@ The guard rejects any normal PR that changes one of these immutable paths:
 - `clusters/kyrion/kustomization.yaml`, `apps.yaml`, `infrastructure.yaml`, or
   `monitoring.yaml`;
 - `infrastructure/configs/flux-instance/kustomization.yaml`, `repository.yaml`, or
-  `release.yaml`.
+  `release.yaml`;
+- `infrastructure/controllers/system-upgrade/controller.yaml`.
 
-Those files define the Flux root composition, child reconciliation paths, and the
-FluxInstance chart and `instance.sync` source. Freezing whole files keeps this guard
+Those files define the Flux root composition, child reconciliation paths, FluxInstance
+chart and `instance.sync` source, and the System Upgrade controller's independent
+GitRepository/Kustomization source boundary. Freezing whole files keeps this guard
 small and avoids recreating the retired critical-resource diff engine, report parsers,
 or policy ratchet. A legitimate bootstrap recovery or source change uses the
 break-glass procedure; ordinary application and infrastructure changes are unaffected.


### PR DESCRIPTION
## What changed

- Adds `infrastructure/controllers/system-upgrade/controller.yaml` to `Flux Bootstrap Guard / guard`.
- Documents that this file co-locates the System Upgrade `GitRepository` URL/ref and the consuming Flux `Kustomization`.

## Break-glass scope

This PR follows the limited break-glass approval recorded in issue #87. The `Protection` ruleset temporarily requires only `PR Validate Simple / validate`; `Flux Bootstrap Guard / guard` was removed only because the guard deliberately freezes its own workflow. The simple required check, PR-only policy, deletion protection, non-fast-forward protection, and strict-up-to-date behavior remain active.

After this PR merges, restore `Flux Bootstrap Guard / guard` as required immediately and run a harmless canary from `main`.

## Validation

- Guard classifier fixtures for unrelated files, FluxInstance source, System Upgrade source, guard self-change, and a protected-file rename
- `yamllint .github/workflows/flux-bootstrap-guard.yml docs/ci/pr-validation.md`
- checksum-pinned `actionlint .github/workflows/flux-bootstrap-guard.yml`
- `git diff --check` and `git show --check`

## Approval

- User approval: received on August 19, 2026 for this PR.
- Initially approved head SHA: `6f8d6b226a6d9cedcec231942607b8af85867456`.
- Current head SHA: `912163812dfb0fe9e93fd74d54ea83eff1661325`, produced solely by rebasing onto `main`.
- The owner-approved authorization-inheritance policy of August 19, 2026 keeps PR approval valid through that mechanical branch synchronization.
- Merge method: native GitHub squash auto-merge.

