### PR TITLE
chore(mux): pin installed version

### DIFF
--- a/coder/templates/kubernetes-devcontainer/main.tf
+++ b/coder/templates/kubernetes-devcontainer/main.tf
@@ -474,14 +474,32 @@ module "jetbrains" {
   folder     = local.workspace_folder
 }
 
-module "mux" {
-  count       = data.coder_workspace.me.start_count
-  source      = "registry.coder.com/coder/mux/coder"
-  version     = "1.5.0"
-  agent_id    = coder_agent.main.id
-  add_project = local.workspace_folder
-  use_cached  = true
-  open_in     = "tab"
+module "codex" {
+  count    = data.coder_workspace.me.start_count
+  source   = "registry.coder.com/coder-labs/codex/coder"
+  version  = "5.3.0"
+  agent_id = coder_agent.main.id
+  workdir  = local.workspace_folder
+  base_config_toml = <<-EOT
+    sandbox_mode = "danger-full-access"
+    approval_policy = "never"
+    preferred_auth_method = "chatgpt"
+    allow_remote_control = true
+  EOT
+}
+
+resource "coder_app" "codex" {
+  agent_id     = coder_agent.main.id
+  slug         = "codex"
+  display_name = "Codex"
+  icon         = "/icon/openai.svg"
+  open_in      = "slim-window"
+  command      = <<-EOT
+    #!/bin/bash
+    set -e
+    cd "${local.workspace_folder}"
+    codex
+  EOT
 }
 
 resource "coder_metadata" "container_info" {

--- a/coder/templates/mux/README.md
+++ b/coder/templates/mux/README.md
@@ -15,7 +15,7 @@ Provisions a Kubernetes workspace running [Mux](https://github.com/coder/mux) â€
 |---|---|
 | **Runtime** | `ghcr.io/coder/envbox:0.6.7` (privileged, built-in Docker daemon) |
 | **Inner image** | `codercom/enterprise-node:ubuntu-20260713` |
-| **Mux** | Installed via `coder/mux` registry module (`mux@next` from npm) |
+| **Mux** | Installed via `coder/mux` registry module (pinned from npm and Renovate-managed) |
 | **Storage** | Single PVC for `/home/coder`, Docker cache, and Mux state (`~/.mux`) |
 
 ## Docker cache stability

--- a/coder/templates/mux/main.tf
+++ b/coder/templates/mux/main.tf
@@ -152,13 +152,14 @@ module "coder-login" {
   agent_id = coder_agent.main.id
 }
 
-# Installs mux@next via npm (falls back to tarball) and runs the mux server as
+# Installs mux via npm (falls back to tarball) and runs the mux server as
 # a workspace process. Generates its own MUX_SERVER_AUTH_TOKEN per workspace
 # instance (stored in Terraform state -- no manual secret management needed).
 module "mux" {
   count                = data.coder_workspace.me.start_count
   source               = "registry.coder.com/coder/mux/coder"
   version              = "1.5.0"
+  install_version      = "0.28.2" # renovate: datasource=github-releases depName=coder/mux extractVersion=^v(?<version>.+)$
   agent_id             = coder_agent.main.id
   additional_arguments = "--host 127.0.0.1"
   subdomain            = true


### PR DESCRIPTION
## What changed

Pins the installed Mux package version in the Coder template and adds a Renovate marker so future releases are proposed automatically. The README now describes the pin as Renovate-managed without duplicating a specific version.

## Why

The workspace should install a reproducible Mux release while keeping upgrades automated.

## Impact

New and restarted Mux workspaces install the pinned release until Renovate opens an update PR.

## Validation

- `renovate-config-validator`
- `terraform fmt -check coder/templates/mux/main.tf`
- `git diff --check`

`terraform validate` could not complete because the existing lockfile pins `hashicorp/kubernetes` 2.38.0 while the template requires `~> 3.2`; this change does not alter provider constraints or lockfiles.