### PR TITLE
chore(devcontainer): install GitHub CLI

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,18 @@
+[mcp_servers.kubernetes]
+command = "npx"
+args = ["-y", "kubernetes-mcp-server@latest"]
+enabled = true
+
+[mcp_servers.flux-operator-mcp]
+url = "http://flux-operator-mcp.flux-system.svc:9090/mcp"
+
+[mcp_servers.grafana]
+url = "http://grafana-mcp.monitoring.svc:8000/mcp"
+
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+env_http_headers = { CONTEXT7_API_KEY = "CONTEXT7_API_KEY" }
+
+[mcp_servers.github]
+url = "https://api.githubcopilot.com/mcp/"
+bearer_token_env_var = "GITHUB_TOKEN"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -12,7 +12,3 @@ url = "http://grafana-mcp.monitoring.svc:8000/mcp"
 [mcp_servers.context7]
 url = "https://mcp.context7.com/mcp"
 env_http_headers = { CONTEXT7_API_KEY = "CONTEXT7_API_KEY" }
-
-[mcp_servers.github]
-url = "https://api.githubcopilot.com/mcp/"
-bearer_token_env_var = "GITHUB_TOKEN"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,6 +52,7 @@
 		"ghcr.io/goldsam/dev-container-features/flux2:1": {},
 		"./features/fission-cli": {},
 		"ghcr.io/devcontainers/features/terraform:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"./features/coder-cli": {},
 		"ghcr.io/tailscale/codespace/tailscale:1": {},
 		"ghcr.io/devcontainers/features/node:2": {},
@@ -66,9 +67,7 @@
 		"ghcr.io/devcontainers-extra/features/renovate-cli:2": {}
 		// Removed ghcr.io/devcontainers/features/azure-cli and
 		// ghcr.io/devcontainers/features/copilot-cli:1: no `az` or
-		// `gh copilot`/copilot-cli usage found anywhere in this repo
-		// (scripts, CI, docs). Node.js remains via features/node:2, which
-		// also provides `npx` for on-demand tools.
+		// `gh copilot`/copilot-cli usage found anywhere in this repo.
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
## What changed

- Adds project-scoped Codex MCP configuration for Kubernetes, Flux Operator, Grafana, and Context7.
- Deliberately omits the GitHub MCP server.
- Declares the official GitHub CLI Dev Container feature.

## Why

The devcontainer already forwards `GH_TOKEN` and runs `gh auth setup-git`; declaring GitHub CLI makes that setup available in rebuilt workspaces without configuring a separate GitHub MCP server.

## Validation

- Verified both commits with `git diff --check`.
- Confirmed the GitHub CLI feature is already pinned in `.devcontainer/devcontainer-lock.json`; no lockfile change is needed.
- Confirmed `etc/kubeconfig` remains outside the PR.