### PR TITLE
test(ci): canary restored Flux guard

### DIFF
--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -330,3 +330,5 @@ checkov -d <rendered-dir> --framework kubernetes --soft-fail
 **Known limitation:** `flux build kustomization` emits `HelmRelease` custom resources but does not
 render their referenced Helm charts. Issue #60 tracks evaluating `flate`, `konflate`, or another
 maintained renderer for this gap.
+
+<!-- Temporary pull-request canary: verifies that the restored trusted-base Flux Bootstrap Guard runs and passes for an unrelated docs-only change. This branch will be closed without merging. -->


### PR DESCRIPTION
## Canary scope

Docs-only, intentionally non-merged canary after restoring strict `guard` and `validate` in the `Protection` ruleset. It verifies that trusted-base `Flux Bootstrap Guard / guard` passes for an unrelated change.

## Validation

- `git diff --check`

## Disposition

Close without merging after both required checks pass.
