### PR TITLE
fix(tsidp): retain state PVC on Helm uninstall

### DIFF
--- a/infrastructure/controllers/tsidp/release.yaml
+++ b/infrastructure/controllers/tsidp/release.yaml
@@ -73,6 +73,8 @@ spec:
       - name: tsidp-data
         path: /data
         size: 1Gi
+        pvcAnnotations:
+          helm.sh/resource-policy: keep
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
## What changed

Adds `helm.sh/resource-policy: keep` to the chart-generated `tsidp-tsidp-data` PersistentVolumeClaim through the local OneChart `volumes[].pvcAnnotations` interface.

The PVC contains tsidp issuer keys, registered clients, and refresh-token state. The existing HelmRelease retention and RetryOnFailure policies do not themselves prevent Helm from deleting the generated PVC during an uninstall, so this completes the plan's missing storage-retention guardrail.

## Validation

- `yamllint infrastructure/controllers/tsidp/release.yaml`
- `helm lint charts/onechart -f <rendered HelmRelease values>`
- `helm template tsidp charts/onechart --namespace tailscale -f <rendered HelmRelease values>`, confirming the rendered PVC has `helm.sh/resource-policy: keep`
- `kustomize build clusters/kyrion/`
- schema checksum verification
- all five Flux build + strict kubeconform surfaces: 150 apps, 38 infrastructure controllers, 38 infrastructure configs, 19 monitoring controllers, 5 monitoring configs; zero invalid/errors/skipped
- `git diff --check`

## Authorization

This PR wholly implements the approved CI-simplification plan's tsidp PVC-retention requirement. Plan authorization permits native squash auto-merge after all required checks pass.

## Rollback

Revert this squash merge to remove the Helm keep annotation. Confirm the resulting PVC lifecycle before any intentional uninstall.
