### PR TITLE
fix(k8up): scope schedule history limits to jobs

### DIFF
--- a/apps/kyrion/ai/openclaw-backup-schedule.yaml
+++ b/apps/kyrion/ai/openclaw-backup-schedule.yaml
@@ -16,7 +16,6 @@ spec:
     volumeMounts:
       - mountPath: /repository
         name: repository
-  failedJobsHistoryLimit: 2
   podSecurityContext:
     fsGroup: 34
     fsGroupChangePolicy: OnRootMismatch
@@ -29,32 +28,37 @@ spec:
     requests:
       cpu: 100m
       memory: 128Mi
-  successfulJobsHistoryLimit: 2
   backup:
     activeDeadlineSeconds: 7200
+    failedJobsHistoryLimit: 2
     labelSelectors:
       - matchLabels:
           app: openclaw
     schedule: '0 */6 * * *'
+    successfulJobsHistoryLimit: 2
     volumes:
       - name: repository
         persistentVolumeClaim:
           claimName: openclaw-backup-repository
   check:
     activeDeadlineSeconds: 7200
+    failedJobsHistoryLimit: 2
     schedule: '0 2 * * 0'
+    successfulJobsHistoryLimit: 2
     volumes:
       - name: repository
         persistentVolumeClaim:
           claimName: openclaw-backup-repository
   prune:
     activeDeadlineSeconds: 7200
+    failedJobsHistoryLimit: 2
     retention:
       keepDaily: 7
       keepHourly: 4
       keepMonthly: 12
       keepWeekly: 5
     schedule: '0 4 * * 0'
+    successfulJobsHistoryLimit: 2
     volumes:
       - name: repository
         persistentVolumeClaim:


### PR DESCRIPTION
## What changed

- move successful and failed Job history limits into the `backup` schedule
- apply the same limits explicitly to scheduled `check` and `prune` operations
- remove the ineffective top-level history-limit fields

## Why

K8up copies the operation-specific specifications when creating Backup, Check,
and Prune resources. The top-level limits therefore remained unset on generated
resources and the operator used its global default of three.

This only affects Kubernetes resource housekeeping; Restic snapshot retention is
unchanged.

## Validation

- `kubectl kustomize apps/kyrion/ai`
- `flux build kustomization apps --path clusters/kyrion`
- `yamllint apps/kyrion/ai/openclaw-backup-schedule.yaml`
- `git diff --check`
