### PR TITLE
test(ci): canary GitHub Script v9 guard

### DIFF
--- a/docs/ci/pr-validation.md
+++ b/docs/ci/pr-validation.md
@@ -136,3 +136,5 @@ For a changed Coder template, run `terraform fmt -check -recursive`,
 `terraform init -backend=false`, and `terraform validate -no-color` in the template
 directory. The workflow verifies the local schema checksum before kubeconform and
 fails when a rendered resource has no schema; do not add `-ignore-missing-schemas`.
+
+<!-- Temporary PR canary: verifies the restored trusted-base Flux Bootstrap Guard after the `actions/github-script` v9 update. This docs-only branch will be closed without merge. -->


### PR DESCRIPTION
## Canary scope

Docs-only, intentionally non-merged canary following the owner-approved break-glass for PR #147. It verifies that the restored trusted-base `Flux Bootstrap Guard / guard`, now using `actions/github-script` v9, runs and passes for an unrelated change.

## Validation

- `git diff --check`

## Disposition

Close without merge after strict `guard` and `validate` pass. Then update issue #87 to conclude the break-glass.
