### PR TITLE
feat(openclaw): verify isolated restore drill

### DIFF
--- a/apps/kyrion/ai/kustomization.yaml
+++ b/apps/kyrion/ai/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
   - openclaw-backup-schedule.yaml
   - openclaw-restore-drill-pvc.yaml
   - openclaw-restore-drill.yaml
+  - openclaw-restore-drill-verification-network-policy.yaml
+  - openclaw-restore-drill-verification-job.yaml
   - openclaw-sealed-secret.yaml
   - openclaw-tls-certificate.yaml
   - openclaw-copilot-auth-secret.yaml
@@ -23,6 +25,11 @@ resources:
   - paperclip-sealed-secret.yaml
 
 configMapGenerator:
+  - name: openclaw-restore-drill-verification
+    files:
+      - openclaw-restore-drill-verify.js
+    options:
+      disableNameSuffixHash: true
   - name: local-ai-helm-values
     files:
       - values.yaml=local-ai-values.yaml

--- a/apps/kyrion/ai/openclaw-restore-drill-verification-job.yaml
+++ b/apps/kyrion/ai/openclaw-restore-drill-verification-job.yaml
@@ -1,0 +1,83 @@
+# Temporary, offline Stage-2 verification of the isolated OpenClaw restore.
+# Keep the completed Job for review; a dedicated cleanup PR removes it with the
+# verifier ConfigMap, deny-all NetworkPolicy, Restore, and scratch PVC.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: openclaw-restore-drill-verification
+  namespace: ai
+  labels:
+    app.kubernetes.io/component: restore-drill-verification
+    app.kubernetes.io/name: openclaw-restore-drill-verification
+spec:
+  activeDeadlineSeconds: 1800
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: restore-drill-verification
+        app.kubernetes.io/name: openclaw-restore-drill-verification
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: verifier
+          # Pinned to the current production OpenClaw image for deterministic,
+          # offline CLI validation without a listener or production credentials.
+          image: "ghcr.io/openclaw/openclaw:2026.7.1@\
+            sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c"
+          imagePullPolicy: IfNotPresent
+          command:
+            - node
+            - /verify/openclaw-restore-drill-verify.js
+          env:
+            - name: NODE_NO_WARNINGS
+              value: "1"
+            - name: RESTORE_ROOT
+              value: /restore
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - name: restore
+              mountPath: /restore
+              readOnly: true
+            - name: verifier
+              mountPath: /verify
+              readOnly: true
+            - name: temporary-storage
+              mountPath: /tmp
+      volumes:
+        - name: restore
+          persistentVolumeClaim:
+            claimName: openclaw-restore-drill
+            readOnly: true
+        - name: verifier
+          configMap:
+            name: openclaw-restore-drill-verification
+        - name: temporary-storage
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi

--- a/apps/kyrion/ai/openclaw-restore-drill-verification-network-policy.yaml
+++ b/apps/kyrion/ai/openclaw-restore-drill-verification-network-policy.yaml
@@ -1,0 +1,14 @@
+# Temporary isolation for the Stage-2 OpenClaw restore-drill verifier only.
+# It does not select production OpenClaw pods.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openclaw-restore-drill-verification
+  namespace: ai
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: openclaw-restore-drill-verification
+  policyTypes:
+    - Ingress
+    - Egress

--- a/apps/kyrion/ai/openclaw-restore-drill-verify.js
+++ b/apps/kyrion/ai/openclaw-restore-drill-verify.js
@@ -1,0 +1,312 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const restoreRoot = process.env.RESTORE_ROOT || "/restore";
+const expectedApplicationUid = 1000;
+const expectedApplicationGid = 1000;
+const expectedDirectoryMode = 0o755;
+const expectedConfigUid = 0;
+const expectedConfigGid = 0;
+const expectedConfigMode = 0o644;
+const startedAt = new Date();
+const startedAtMs = Date.now();
+
+let fileCount = 0;
+let dataBytes = 0;
+let databaseCount = 0;
+const aggregate = crypto.createHash("sha256");
+const configCandidates = [];
+const databaseCandidates = [];
+
+class VerificationError extends Error {
+  constructor(code) {
+    super(code);
+    this.code = code;
+  }
+}
+
+function fail(code) {
+  throw new VerificationError(code);
+}
+
+function modeOf(stat) {
+  return stat.mode & 0o7777;
+}
+
+function updateText(value) {
+  aggregate.update(value, "utf8");
+  aggregate.update("\0", "utf8");
+}
+
+async function sha256File(filePath) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash("sha256");
+    const stream = fs.createReadStream(filePath);
+
+    stream.on("error", reject);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+async function walk(directory, relativeDirectory = "") {
+  let entries;
+  try {
+    entries = await fsp.readdir(directory, { withFileTypes: true });
+  } catch {
+    fail("restore_tree_unreadable");
+  }
+
+  entries.sort((left, right) =>
+    Buffer.compare(Buffer.from(left.name), Buffer.from(right.name)),
+  );
+
+  for (const entry of entries) {
+    const relativePath = relativeDirectory
+      ? `${relativeDirectory}/${entry.name}`
+      : entry.name;
+    const absolutePath = path.join(directory, entry.name);
+    let stat;
+
+    try {
+      stat = await fsp.lstat(absolutePath);
+    } catch {
+      fail("restore_tree_unreadable");
+    }
+
+    updateText(relativePath);
+    updateText(String(stat.uid));
+    updateText(String(stat.gid));
+    updateText(String(modeOf(stat)));
+
+    if (stat.isDirectory()) {
+      updateText("directory");
+      await walk(absolutePath, relativePath);
+      continue;
+    }
+
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      fail("unexpected_restore_entry");
+    }
+
+    const fileDigest = await sha256File(absolutePath).catch(() =>
+      fail("restore_file_unreadable"),
+    );
+    updateText("file");
+    updateText(String(stat.size));
+    updateText(fileDigest);
+    fileCount += 1;
+    dataBytes += stat.size;
+
+    if (
+      relativePath === ".openclaw/openclaw.json" ||
+      relativePath.endsWith("/.openclaw/openclaw.json")
+    ) {
+      configCandidates.push(absolutePath);
+    }
+
+    if (/\.(?:db|sqlite|sqlite3)$/i.test(entry.name)) {
+      databaseCandidates.push(absolutePath);
+    }
+  }
+}
+
+async function expectMetadata(filePath, expected, kind) {
+  let stat;
+  try {
+    stat = await fsp.stat(filePath);
+  } catch {
+    fail("expected_layout_missing");
+  }
+
+  const matchesKind = kind === "directory" ? stat.isDirectory() : stat.isFile();
+  if (
+    !matchesKind ||
+    stat.uid !== expected.uid ||
+    stat.gid !== expected.gid ||
+    modeOf(stat) !== expected.mode
+  ) {
+    fail("unexpected_ownership_or_mode");
+  }
+}
+
+async function parseConfig(configPath) {
+  let config;
+  try {
+    config = JSON.parse(await fsp.readFile(configPath, "utf8"));
+  } catch {
+    fail("config_json_parse");
+  }
+
+  if (config === null || Array.isArray(config) || typeof config !== "object") {
+    fail("config_json_shape");
+  }
+}
+
+function validateConfigWithOpenClaw(configPath) {
+  const temporaryHome = "/tmp/openclaw-restore-drill";
+  try {
+    for (const directory of [
+      temporaryHome,
+      "/tmp/cache",
+      "/tmp/config",
+      "/tmp/data",
+    ]) {
+      fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    }
+  } catch {
+    fail("temporary_storage_unavailable");
+  }
+
+  const validation = spawnSync(
+    "node",
+    ["/app/dist/index.js", "config", "validate"],
+    {
+      cwd: temporaryHome,
+      env: {
+        HOME: temporaryHome,
+        NODE_NO_WARNINGS: "1",
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_NIX_MODE: "1",
+        PATH: process.env.PATH || "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        TMPDIR: "/tmp",
+        XDG_CACHE_HOME: "/tmp/cache",
+        XDG_CONFIG_HOME: "/tmp/config",
+        XDG_DATA_HOME: "/tmp/data",
+      },
+      stdio: "ignore",
+      timeout: 120_000,
+    },
+  );
+
+  if (validation.error || validation.signal || validation.status !== 0) {
+    fail("offline_config_validation");
+  }
+}
+
+async function isSqliteDatabase(filePath) {
+  let handle;
+  try {
+    handle = await fsp.open(filePath, "r");
+    const header = Buffer.alloc(16);
+    const { bytesRead } = await handle.read(header, 0, header.length, 0);
+    return bytesRead === 16 && header.equals(Buffer.from("SQLite format 3\0"));
+  } catch {
+    fail("database_unreadable");
+  } finally {
+    await handle?.close();
+  }
+}
+
+function verifySqliteIntegrity(filePath) {
+  let database;
+  try {
+    const { DatabaseSync } = require("node:sqlite");
+    database = new DatabaseSync(filePath, { readOnly: true });
+    const result = database.prepare("PRAGMA integrity_check").get();
+    if (!result || Object.values(result).length !== 1 || Object.values(result)[0] !== "ok") {
+      fail("sqlite_integrity");
+    }
+  } catch (error) {
+    if (error instanceof VerificationError) {
+      throw error;
+    }
+    fail("sqlite_integrity");
+  } finally {
+    database?.close();
+  }
+}
+
+function report(result, check, aggregateChecksum) {
+  const durationSeconds = ((Date.now() - startedAtMs) / 1000).toFixed(3);
+  const fields = [
+    `result=${result}`,
+    `timestamp=${startedAt.toISOString()}`,
+    `duration_seconds=${durationSeconds}`,
+    `file_count=${fileCount}`,
+    `data_bytes=${dataBytes}`,
+    `database_count=${databaseCount}`,
+  ];
+
+  if (aggregateChecksum) {
+    fields.push(`aggregate_sha256=${aggregateChecksum}`);
+  }
+  if (check) {
+    fields.push(`check=${check}`);
+  }
+
+  console.log(fields.join(" "));
+}
+
+async function main() {
+  let rootStat;
+  try {
+    rootStat = await fsp.lstat(restoreRoot);
+  } catch {
+    fail("restore_root_missing");
+  }
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    fail("restore_root_invalid");
+  }
+
+  await walk(restoreRoot);
+  if (fileCount === 0 || dataBytes === 0 || configCandidates.length !== 1) {
+    fail("unexpected_restore_data");
+  }
+
+  const configPath = configCandidates[0];
+  const applicationHome = path.dirname(configPath);
+  const workspacePath = path.join(applicationHome, "workspace");
+
+  await expectMetadata(
+    applicationHome,
+    {
+      uid: expectedApplicationUid,
+      gid: expectedApplicationGid,
+      mode: expectedDirectoryMode,
+    },
+    "directory",
+  );
+  await expectMetadata(
+    workspacePath,
+    {
+      uid: expectedApplicationUid,
+      gid: expectedApplicationGid,
+      mode: expectedDirectoryMode,
+    },
+    "directory",
+  );
+  await expectMetadata(
+    configPath,
+    {
+      uid: expectedConfigUid,
+      gid: expectedConfigGid,
+      mode: expectedConfigMode,
+    },
+    "file",
+  );
+
+  await parseConfig(configPath);
+  validateConfigWithOpenClaw(configPath);
+
+  for (const databasePath of databaseCandidates) {
+    if (!(await isSqliteDatabase(databasePath))) {
+      fail("unexpected_database_format");
+    }
+    verifySqliteIntegrity(databasePath);
+    databaseCount += 1;
+  }
+
+  report("pass", null, aggregate.digest("hex"));
+}
+
+main().catch((error) => {
+  const check = error instanceof VerificationError ? error.code : "verification_error";
+  report("fail", check, null);
+  process.exitCode = 1;
+});

--- a/docs/runbooks/backup-and-restore.md
+++ b/docs/runbooks/backup-and-restore.md
@@ -124,20 +124,56 @@ identifier, restored content, repository path, or credentials. A failed Restore
 must be handled by reverting the stage-1 GitOps change or correcting it in a
 new scoped PR; production remains outside the restore target.
 
-### Stage 2: verification and cleanup
+### Stage 2: isolated verification and cleanup
 
-Only after Stage 1 has succeeded may a follow-up GitOps PR add a deny-all
-NetworkPolicy and a read-only verification workload that mounts the scratch
-claim. Validate file count and aggregate size, a deterministic aggregate
-checksum, ownership and modes, configuration parsing, native database
-integrity, and offline application startup. Record only timestamps, duration,
-aggregate counts, results, and RPO/RTO compliance.
+Only after Stage 1 has succeeded may a follow-up GitOps PR add the temporary
+`openclaw-restore-drill-verification` Job, its ConfigMap script, and a deny-all
+NetworkPolicy. The policy selects only that Job's unique pod label and has no
+ingress or egress rules. The Job mounts only `openclaw-restore-drill` as a
+read-only PVC; its other volumes are the read-only verifier ConfigMap and an
+in-memory `emptyDir` for temporary files. It has no Service, Ingress, production
+PVC, repository PVC, Secret, TLS material, or ServiceAccount token. It runs as
+UID/GID 1000 with RuntimeDefault seccomp, a read-only root filesystem, no
+privilege escalation, and all Linux capabilities dropped.
 
-After verification, a separate cleanup PR must remove the temporary Restore,
-any generated verification resources, and `openclaw-restore-drill` in that
-order. Preserve the production workload and PVC, the backup Schedule, the
-repository PV/PVC, the password Secret, and Restic data throughout both the
-verification and cleanup changes.
+The verifier walks the restored tree without emitting names or content. It fails
+closed if the tree has unexpected entry types, an unexpected configuration
+layout, unreadable data, or unexpected ownership/modes. It records only UTC
+timestamps, duration, file count, aggregate bytes, database count, one generic
+check result, and a deterministic aggregate SHA-256 checksum on success. It
+parses the configuration JSON, verifies the expected application home/workspace
+and config-file UID/GID/modes, and runs `PRAGMA integrity_check` read-only for
+each detected SQLite database.
+
+For an application-aware offline check, the pinned OpenClaw image runs
+`openclaw config validate` through its native CLI with an explicit restored
+configuration path and a writable temporary home. This validates the active
+schema without starting the gateway; the Job does not invoke `gateway run` or
+open a listener. No meaningful offline gateway-start/health check has been
+established without mounting the production gateway credential and TLS material
+or binding the gateway, all of which are intentionally prohibited here. Do not
+claim an application-startup check from this drill; treat the native config
+validation plus filesystem/database checks as its Stage-2 evidence.
+
+After the Stage-2 PR merges, use read-only MCP queries to confirm the Flux
+`apps` Kustomization is Ready, the NetworkPolicy selects only the verifier pod,
+and the Job reaches exactly one successful completion with no retries. Read the
+verifier's one redacted aggregate result only after it completes; do not collect
+or publish any other logs, restored files, paths, configuration, credentials, or
+snapshot/repository details. Independently confirm the production OpenClaw
+Deployment remains available with one replica and its production PVC identity is
+unchanged. Because `apps` uses `wait: false`, the bounded one-shot Job does not
+block Flux reconciliation; retain the completed Job for this review evidence and
+do not set a TTL that Flux would recreate.
+
+After the evidence is recorded, a separate cleanup PR must remove only the
+verification ConfigMap, verification Job, verification NetworkPolicy, temporary
+Restore, and `openclaw-restore-drill` scratch PVC. It must preserve the K8up
+Schedule, repository PV/PVC, repository password Secret, Restic data, production
+OpenClaw Deployment/PVC/Secrets/TLS, and all unrelated resources. Before
+verification evidence is available, reverting the Stage-2 PR removes only its
+ConfigMap, Job, and NetworkPolicy through GitOps; it leaves the Stage-1 Restore
+and scratch PVC intact.
 
 ## Operator-independent Restic recovery
 


### PR DESCRIPTION
## Summary

- Adds the temporary Stage-2 OpenClaw restore-drill verifier: a raw, bounded Job and generated non-sensitive verifier ConfigMap.
- Adds a deny-all NetworkPolicy whose selector matches only the verifier pod; the Job has no Service or Ingress and mounts only the scratch restore claim as a read-only PVC.
- Enforces a non-privileged runtime (no service-account token, RuntimeDefault seccomp, UID/GID 1000, no privilege escalation, dropped capabilities, read-only root filesystem, and bounded resources).
- Performs redacted aggregate filesystem checks, expected ownership/mode checks, JSON parsing, native offline configuration validation, and read-only SQLite integrity checks when a database is present.
- Expands the backup runbook with acceptance monitoring, rollback, exact cleanup boundaries, and the offline-startup limitation.

## Production-safety assertions

- No production OpenClaw Deployment, production PVC, K8up Schedule, repository PVC, repository password Secret, application Secret, TLS material, Service, Certificate, source Kustomization, or image automation resource is modified.
- The verifier has no Secret reference and no repository or production claim mount. The only PVC it references is the temporary scratch restore claim, mounted read-only.
- The completed Job deliberately has no TTL: the parent `apps` Kustomization uses `wait: false`, so this bounded one-shot Job does not block reconciliation and will remain available as review evidence until the cleanup PR.

## Validation

- `node --check apps/kyrion/ai/openclaw-restore-drill-verify.js`
- Representative verifier failure/success checks, including a SQLite integrity path and redacted-output assertions.
- `yamllint` on the changed YAML.
- `git diff --check`
- `.github/schemas` checksum verification (including K8up Restore/Schedule schemas).
- `kustomize build apps/kyrion/ai`
- `flux build kustomization apps --path clusters/kyrion`
- CI-equivalent `flux build ... --dry-run | kubeconform -strict -summary` with the repository schemas and pinned CRD catalog; **155 valid, 0 invalid, 0 errors, 0 skipped**.
- Rendered-manifest isolation assertions for the policy, claim-only volume set, Pod hardening, no Secret references, and no production/repository/TLS references.

## Post-merge MCP monitoring plan

1. Use read-only MCP queries to confirm Flux `apps` is Ready at the merged revision.
2. Confirm the NetworkPolicy selects only the verifier pod label and has no ingress/egress rules; confirm the verifier has only the scratch PVC, verifier ConfigMap, and temporary `emptyDir` volumes.
3. Confirm the Job reaches one successful completion with no retries. Read only its single redacted aggregate result after completion; do not collect or publish any other logs or restored data.
4. Independently verify that the production OpenClaw Deployment remains available with one replica and its production PVC identity is unchanged.

## Offline startup limitation

The Job uses OpenClaw's native `config validate` capability, which validates the restored configuration without starting the gateway. No safe, meaningful offline gateway-start/health check was established without production gateway credentials/TLS or binding a listener, so this PR does **not** claim one.

## Rollback and cleanup

- Before verification evidence exists, revert this PR through GitOps to remove only the verifier ConfigMap, Job, and NetworkPolicy.
- After evidence is recorded, a separate cleanup PR must remove the verifier ConfigMap, Job, NetworkPolicy, temporary Restore, and scratch PVC; it must preserve all K8up Schedule/repository/production resources.

Auto-merge is intentionally not enabled.
