### PR TITLE
fix(openclaw): avoid Flux substitution in verifier

### DIFF
--- a/apps/kyrion/ai/openclaw-restore-drill-verify.js
+++ b/apps/kyrion/ai/openclaw-restore-drill-verify.js
@@ -68,7 +68,7 @@ async function walk(directory, relativeDirectory = "") {
 
   for (const entry of entries) {
     const relativePath = relativeDirectory
-      ? `${relativeDirectory}/${entry.name}`
+      ? relativeDirectory + "/" + entry.name
       : entry.name;
     const absolutePath = path.join(directory, entry.name);
     let stat;
@@ -225,19 +225,19 @@ function verifySqliteIntegrity(filePath) {
 function report(result, check, aggregateChecksum) {
   const durationSeconds = ((Date.now() - startedAtMs) / 1000).toFixed(3);
   const fields = [
-    `result=${result}`,
-    `timestamp=${startedAt.toISOString()}`,
-    `duration_seconds=${durationSeconds}`,
-    `file_count=${fileCount}`,
-    `data_bytes=${dataBytes}`,
-    `database_count=${databaseCount}`,
+    "result=" + result,
+    "timestamp=" + startedAt.toISOString(),
+    "duration_seconds=" + durationSeconds,
+    "file_count=" + fileCount,
+    "data_bytes=" + dataBytes,
+    "database_count=" + databaseCount,
   ];
 
   if (aggregateChecksum) {
-    fields.push(`aggregate_sha256=${aggregateChecksum}`);
+    fields.push("aggregate_sha256=" + aggregateChecksum);
   }
   if (check) {
-    fields.push(`check=${check}`);
+    fields.push("check=" + check);
   }
 
   console.log(fields.join(" "));

--- a/apps/kyrion/ai/validate-openclaw-restore-drill-verifier.sh
+++ b/apps/kyrion/ai/validate-openclaw-restore-drill-verifier.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Local regression check:
+#   bash apps/kyrion/ai/validate-openclaw-restore-drill-verifier.sh
+#
+# The verifier is generated into a ConfigMap and therefore passes through the
+# apps Kustomization's Flux post-build substitution. Keep JavaScript template
+# expressions out of the generated source: Flux treats raw ${...} as variables.
+set -euo pipefail
+
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+cd "$repo_root"
+
+verifier="apps/kyrion/ai/openclaw-restore-drill-verify.js"
+
+if grep -Fq "\${" "$verifier"; then
+  printf 'Flux-unsafe template expression found in %s\n' "$verifier" >&2
+  exit 1
+fi
+
+node --check "$verifier"
+kustomize build apps/kyrion/ai | flux envsubst >/dev/null


### PR DESCRIPTION
## Summary

- Corrects the Flux post-build substitution regression merged in PR #163 (`bb0c03c5740342c331d5edc9c979225625b1668f`) on August 21, 2026.
- Replaces the verifier's JavaScript template literals with equivalent string concatenation, so generated ConfigMap source contains no raw Flux variable-expression markers.
- Adds the application-local regression command:
  `bash apps/kyrion/ai/validate-openclaw-restore-drill-verifier.sh`.
  It rejects raw Flux-sensitive markers in the verifier source, checks JavaScript syntax, renders the AI overlay, and passes that render through Flux `envsubst`.

## Regression and scope

The failure is reproducible from the merged source with:

```bash
kustomize build apps/kyrion/ai | flux envsubst
```

which exits with `missing closing brace`. The generated verifier ConfigMap is part of the `apps` Kustomization, whose existing post-build substitution treats JavaScript template expressions as substitution syntax.

This PR changes only the verifier source and its local validation command. It does not change any production manifest, restore resource, Schedule, backup repository, Secret, K8up platform component, NetworkPolicy, Job/pod boundary, CI policy, or Flux Kustomization topology. Rendered resource identities are unchanged (32 before and after). Applying this correction restores reconciliation of the existing intended Stage-2 verifier ConfigMap, Job, and deny-all NetworkPolicy; it introduces no new resource scope.

## Validation

- Negative regression-guard test: injects a temporary raw Flux marker and confirms the new local command rejects it.
- `node --check apps/kyrion/ai/openclaw-restore-drill-verify.js`
- `bash -n` and `shellcheck` on `apps/kyrion/ai/validate-openclaw-restore-drill-verifier.sh`
- `bash apps/kyrion/ai/validate-openclaw-restore-drill-verifier.sh`
- Nested non-sensitive verifier fixture: validates traversal/metadata/JSON up to the expected offline image-local validation boundary, verifies report format, and asserts that the restore path is not emitted.
- `yamllint .` (passes; only existing repository line-length warnings)
- `git diff --check`
- `kustomize build apps/kyrion/ai`
- `kustomize build clusters/kyrion/`
- `flux build kustomization apps --path clusters/kyrion`
- `.github/schemas` checksum verification
- CI-equivalent `flux build kustomization apps --path ./apps/kyrion --kustomization-file clusters/kyrion/apps.yaml --dry-run | kubeconform -strict -summary` with repository schemas and the pinned CRD catalog: **155 valid, 0 invalid, 0 errors, 0 skipped**.
- Rendered identity comparison against `origin/main`: **32 resource identities unchanged**.

## Post-merge read-only monitoring

1. Confirm `Kustomization/flux-system/apps` becomes Ready at the merge revision without a post-build error.
2. Confirm the existing Stage-2 verifier ConfigMap, deny-all NetworkPolicy, and bounded Job reconcile; inspect only the Job's single redacted aggregate result.
3. Confirm the production OpenClaw Deployment remains available and its production PVC identity remains unchanged.

Auto-merge is intentionally not enabled.
