### PR TITLE
fix(openclaw): verify safe restore symlinks

### DIFF
--- a/apps/kyrion/ai/openclaw-restore-drill-verify.js
+++ b/apps/kyrion/ai/openclaw-restore-drill-verify.js
@@ -19,6 +19,7 @@ const startedAtMs = Date.now();
 let fileCount = 0;
 let dataBytes = 0;
 let databaseCount = 0;
+let symlinkCount = 0;
 const aggregate = crypto.createHash("sha256");
 const configCandidates = [];
 const databaseCandidates = [];
@@ -52,6 +53,22 @@ async function sha256File(filePath) {
     stream.on("data", (chunk) => hash.update(chunk));
     stream.on("end", () => resolve(hash.digest("hex")));
   });
+}
+
+function isSafeRelativeRestoreSymlink(absolutePath, target) {
+  if (path.isAbsolute(target)) {
+    return false;
+  }
+
+  const resolvedRestoreRoot = path.resolve(restoreRoot);
+  const resolvedTarget = path.resolve(path.dirname(absolutePath), target);
+  const relativeTarget = path.relative(resolvedRestoreRoot, resolvedTarget);
+
+  return (
+    relativeTarget !== ".." &&
+    !relativeTarget.startsWith(".." + path.sep) &&
+    !path.isAbsolute(relativeTarget)
+  );
 }
 
 async function walk(directory, relativeDirectory = "") {
@@ -90,7 +107,25 @@ async function walk(directory, relativeDirectory = "") {
       continue;
     }
 
-    if (stat.isSymbolicLink() || !stat.isFile()) {
+    if (stat.isSymbolicLink()) {
+      let target;
+      try {
+        target = await fsp.readlink(absolutePath);
+      } catch {
+        fail("restore_symlink_unreadable");
+      }
+
+      if (!isSafeRelativeRestoreSymlink(absolutePath, target)) {
+        fail("unsafe_restore_symlink");
+      }
+
+      updateText("symlink");
+      updateText(target);
+      symlinkCount += 1;
+      continue;
+    }
+
+    if (!stat.isFile()) {
       fail("unexpected_restore_entry");
     }
 
@@ -231,6 +266,7 @@ function report(result, check, aggregateChecksum) {
     "file_count=" + fileCount,
     "data_bytes=" + dataBytes,
     "database_count=" + databaseCount,
+    "symlink_count=" + symlinkCount,
   ];
 
   if (aggregateChecksum) {
@@ -305,8 +341,12 @@ async function main() {
   report("pass", null, aggregate.digest("hex"));
 }
 
-main().catch((error) => {
-  const check = error instanceof VerificationError ? error.code : "verification_error";
-  report("fail", check, null);
-  process.exitCode = 1;
-});
+module.exports = { isSafeRelativeRestoreSymlink };
+
+if (require.main === module) {
+  main().catch((error) => {
+    const check = error instanceof VerificationError ? error.code : "verification_error";
+    report("fail", check, null);
+    process.exitCode = 1;
+  });
+}

--- a/apps/kyrion/ai/validate-openclaw-restore-drill-verifier.sh
+++ b/apps/kyrion/ai/validate-openclaw-restore-drill-verifier.sh
@@ -19,4 +19,16 @@ if grep -Fq "\${" "$verifier"; then
 fi
 
 node --check "$verifier"
+node - "$verifier" <<'NODE'
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const verifierPath = path.resolve(process.argv[2]);
+const { isSafeRelativeRestoreSymlink } = require(verifierPath);
+const linkPath = "/restore/.openclaw/workspace/link";
+
+assert.equal(isSafeRelativeRestoreSymlink(linkPath, "../shared"), true);
+assert.equal(isSafeRelativeRestoreSymlink(linkPath, "/etc/passwd"), false);
+assert.equal(isSafeRelativeRestoreSymlink(linkPath, "../../../outside"), false);
+NODE
+
 kustomize build apps/kyrion/ai | flux envsubst >/dev/null

--- a/docs/runbooks/backup-and-restore.md
+++ b/docs/runbooks/backup-and-restore.md
@@ -137,13 +137,16 @@ UID/GID 1000 with RuntimeDefault seccomp, a read-only root filesystem, no
 privilege escalation, and all Linux capabilities dropped.
 
 The verifier walks the restored tree without emitting names or content. It fails
-closed if the tree has unexpected entry types, an unexpected configuration
-layout, unreadable data, or unexpected ownership/modes. It records only UTC
-timestamps, duration, file count, aggregate bytes, database count, one generic
-check result, and a deterministic aggregate SHA-256 checksum on success. It
-parses the configuration JSON, verifies the expected application home/workspace
-and config-file UID/GID/modes, and runs `PRAGMA integrity_check` read-only for
-each detected SQLite database.
+closed if the tree has special entry types, an unexpected configuration layout,
+unreadable data, unexpected ownership/modes, or a symlink with an absolute or
+out-of-tree target. It accepts only relative symlinks whose lexical target stays
+inside the restored tree, incorporates their metadata and target into the
+aggregate checksum without following them, and records only UTC timestamps,
+duration, file count, aggregate bytes, database count, symlink count, one
+generic check result, and a deterministic aggregate SHA-256 checksum on success.
+It parses the configuration JSON, verifies the expected application
+home/workspace and config-file UID/GID/modes, and runs `PRAGMA integrity_check`
+read-only for each detected SQLite database.
 
 For an application-aware offline check, the pinned OpenClaw image runs
 `openclaw config validate` through its native CLI with an explicit restored


### PR DESCRIPTION
## What changed

- Handles the isolated Stage-2 drill failure reported as `unexpected_restore_entry`.
- The existing verifier intentionally collapsed symbolic links and special filesystem entries into that one redacted result, so the completed Job does not identify the entry type.
- Accepts only relative symlinks whose lexical target remains inside the scratch restore tree; it never follows them and hashes their metadata and target into the existing redacted aggregate result.
- Continues to fail closed for absolute or out-of-tree symlink targets and special filesystem entries.
- Adds a symlink-regression check and updates the restore-drill runbook with the precise verification boundary.

## Safety

- No production workload, production PVC, repository PVC, K8up Restore, Schedule, Secret, TLS material, or NetworkPolicy definition changes.
- The deployed Job remains isolated, read-only against the scratch PVC, and emits no filenames, targets, or restored content.

## Validation

- `bash apps/kyrion/ai/validate-openclaw-restore-drill-verifier.sh`
- `node --check apps/kyrion/ai/openclaw-restore-drill-verify.js`
- `bash -n apps/kyrion/ai/validate-openclaw-restore-drill-verifier.sh`
- `git diff --check`
- `kustomize build apps/kyrion/ai | flux envsubst`
- `kustomize build clusters/kyrion`
- `flux build kustomization apps --path clusters/kyrion`
- Kubeconform strict renders: no invalid resources or errors.
- `yamllint` and `shellcheck` are unavailable in this devcontainer; PR CI will run its applicable validation.
