### PR TITLE
fix(openclaw): rerun restore verification

### DIFF
--- a/apps/kyrion/ai/openclaw-restore-drill-verification-job.yaml
+++ b/apps/kyrion/ai/openclaw-restore-drill-verification-job.yaml
@@ -1,10 +1,11 @@
 # Temporary, offline Stage-2 verification of the isolated OpenClaw restore.
-# Keep the completed Job for review; a dedicated cleanup PR removes it with the
-# verifier ConfigMap, deny-all NetworkPolicy, Restore, and scratch PVC.
+# This distinct retry Job reruns the corrected verifier once; a dedicated cleanup
+# PR removes it with the verifier ConfigMap, deny-all NetworkPolicy, Restore,
+# and scratch PVC.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: openclaw-restore-drill-verification
+  name: openclaw-restore-drill-verification-retry-1
   namespace: ai
   labels:
     app.kubernetes.io/component: restore-drill-verification

--- a/docs/runbooks/backup-and-restore.md
+++ b/docs/runbooks/backup-and-restore.md
@@ -128,7 +128,7 @@ new scoped PR; production remains outside the restore target.
 
 Only after Stage 1 has succeeded may a follow-up GitOps PR add the temporary
 `openclaw-restore-drill-verification` Job, its ConfigMap script, and a deny-all
-NetworkPolicy. The policy selects only that Job's unique pod label and has no
+NetworkPolicy. The policy selects only that Job's dedicated pod label and has no
 ingress or egress rules. The Job mounts only `openclaw-restore-drill` as a
 read-only PVC; its other volumes are the read-only verifier ConfigMap and an
 in-memory `emptyDir` for temporary files. It has no Service, Ingress, production
@@ -168,6 +168,13 @@ Deployment remains available with one replica and its production PVC identity is
 unchanged. Because `apps` uses `wait: false`, the bounded one-shot Job does not
 block Flux reconciliation; retain the completed Job for this review evidence and
 do not set a TTL that Flux would recreate.
+
+A failed one-shot Job never reruns when only its referenced ConfigMap changes.
+After correcting verifier code, a follow-up GitOps PR must replace it with one
+new, distinctly named, one-shot Job that retains the same isolation, read-only
+mount, resource, and pod-label constraints. Do not imperatively delete or rerun
+the Job. Record the failed attempt separately, then assess only the new Job for
+the single successful completion required as Stage-2 evidence.
 
 After the evidence is recorded, a separate cleanup PR must remove only the
 verification ConfigMap, verification Job, verification NetworkPolicy, temporary


### PR DESCRIPTION
## What changed

- Replaces the terminal failed Stage-2 verifier Job with the distinctly named one-shot Job `openclaw-restore-drill-verification-retry-1`.
- Kubernetes Jobs do not rerun when a referenced ConfigMap changes; this change is the GitOps-safe retry of the corrected verifier merged in #165.
- Retains the same read-only scratch-PVC mount, deny-all NetworkPolicy-selected pod label, no-token setting, RuntimeDefault seccomp, UID/GID 1000, resource bounds, and zero retry policy.
- Documents the one-shot retry requirement and explicitly prohibits imperative Job deletion/reruns.

## Safety and scope

- No changes to the production OpenClaw Deployment/PVC, repository PV/PVC, K8up Restore/Schedule, Sealed Secrets, TLS, NetworkPolicy definition, or verifier code.
- Flux will create a new isolated Job and prune the previous terminal Job by its old resource identity. Neither Job mounts the production PVC or repository PVC.

## Merge authorization

- Authorized by the accepted implementation plan for the OpenClaw Stage-2 restore drill, whose scope requires a successful isolated verifier run via squash auto-merge PRs.

## Validation

- `bash apps/kyrion/ai/validate-openclaw-restore-drill-verifier.sh`
- `node --check apps/kyrion/ai/openclaw-restore-drill-verify.js`
- `bash -n apps/kyrion/ai/validate-openclaw-restore-drill-verifier.sh`
- `git diff --check`
- `kustomize build apps/kyrion/ai | flux envsubst`
- `kustomize build clusters/kyrion`
- `flux build kustomization apps --path clusters/kyrion`
- `kustomize build apps/kyrion/ai | flux envsubst | kubeconform -strict -summary -ignore-missing-schemas` (13 valid, 0 invalid, 0 errors; 19 schema skips)
- `yamllint` and `shellcheck` are unavailable in this devcontainer; applicable PR CI will run.
