### PR TITLE
Disable cached installation for mux binary

### DIFF
--- a/coder/templates/mux/main.tf
+++ b/coder/templates/mux/main.tf
@@ -168,7 +168,7 @@ module "mux" {
   # use_cached skips reinstall when the binary is already present.
   install_prefix = "/home/coder/.local/bin"
   log_path       = "/home/coder/.mux/mux.log"
-  use_cached     = true
+  use_cached     = false
   open_in        = "tab"
 }
 


### PR DESCRIPTION
Disable the cached installation for the mux binary to ensure that the latest version is always installed. This change enhances the reliability of the installation process.

