### PR TITLE
chore(openclaw): prepare OneChart ownership handoff

### DIFF
--- a/apps/base/openclaw/openclaw-install.yaml
+++ b/apps/base/openclaw/openclaw-install.yaml
@@ -12,7 +12,10 @@ spec:
     kind: GitRepository
     name: openclaw
   path: ./scripts/k8s/manifests
-  prune: true
+  # Keep the current resources when this source Kustomization is removed in the
+  # subsequent OneChart cutover; Flux Helm can then adopt them without a race.
+  prune: false
+  deletionPolicy: Orphan
   wait: true
   postBuild:
     substituteFrom:


### PR DESCRIPTION
## Purpose

Prepare the existing Flux-managed OpenClaw resources for the subsequent OneChart cutover without changing the running workload, its Service, its configuration, its TLS/Secrets, or `openclaw-home-pvc`.

## Change

- Change `Kustomization/ai/openclaw` from `prune: true` to `prune: false`.
- Set `deletionPolicy: Orphan` so removing this upstream-source Kustomization in the next PR retains its current inventory for Helm adoption rather than racing a prune.

## Risk and rollback

No production workload specification, source revision, PVC, Service, Secret, Certificate, image automation, or K8up resource changes in this PR. The Deployment remains the sole RWO PVC writer. If the handoff reconciliation regresses, revert this commit through a new PR; the known-good pre-handoff Git revision is `712e35afe3dc97c8d67f0a65732545984fd0f292`.

## Validation

- `git diff --check`
- `kustomize build apps/base/openclaw`
- `kustomize build apps/kyrion/ai | flux envsubst`
- `flux build kustomization apps --path clusters/kyrion`
- `kustomize build apps/kyrion/ai | flux envsubst | kubeconform -strict -summary -ignore-missing-schemas` — 9 valid, 0 invalid, 0 errors; 18 schema skips.
- Server-side dry-run of the OpenClaw base resources accepted all 4 objects.
- `yamllint` is not installed in this devcontainer; `helm unittest` is unavailable because the Helm unittest plugin is not installed. OneChart is unchanged.

## Merge authorization

- [ ] Awaiting explicit user approval of the current head SHA before enabling native squash auto-merge.

Refs #121.
